### PR TITLE
Добавить параметры чувствительности к регистру и использования семени в классе basic_hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(SHADOWSYSCALL_BUILD_TESTS) # shadowsyscall-build-tests
 		"tests/cache.cpp"
 		"tests/dll_export.cpp"
 		"tests/forwarded_exports.cpp"
+		"tests/hasher.cpp"
 		"tests/nt_memory_allocator.cpp"
 		"tests/shared_data.cpp"
 		"tests/syscaller.cpp"

--- a/include/shadowsyscall.hpp
+++ b/include/shadowsyscall.hpp
@@ -1195,21 +1195,29 @@ namespace shadow {
     constexpr uint64_t library_seed = 0x8953484829149489ull;
 #endif
 
+    template <std::integral Ty = std::uint64_t>
+    struct hasher_opts {
+      bool case_sensitive = false;
+      bool seed = true;
+      Ty custom_seed{0};
+    };
+
+    constexpr auto default_hasher_opts = hasher_opts<>{};
+
     // basic_hash class provides compile-time and runtime hash
     // computation. Uses FNV-1a hashing algorithm.
     // Case-insensitive by default.
     // cs - case sensitivity
     // seed - whether to use library seed in case reference fnv is desired.
-    template <std::integral ValTy, bool cs = false, bool seed = true>
+    template <std::integral ValTy, hasher_opts Opts = default_hasher_opts>
     class basic_hash {
-     public:
-      using underlying_t = ValTy;
-      constexpr static bool case_sensitive = false;
       constexpr static ValTy FNV_prime = (sizeof(ValTy) == 4) ? 16777619u : 1099511628211ull;
       constexpr static ValTy FNV_offset_basis =
           (sizeof(ValTy) == 4) ? 2166136261u : 14695981039346656037ull;
 
      public:
+      using underlying_t = ValTy;
+
       constexpr basic_hash(ValTy hash) : m_value(hash) {}
       constexpr basic_hash() = default;
       constexpr ~basic_hash() = default;
@@ -1230,7 +1238,11 @@ namespace shadow {
           m_value = fnv1a_append_bytes<>(m_value, string[i]);
       }
 
-     public:
+      consteval basic_hash(std::string_view string) {
+        for (auto i = 0; i < string.size(); i++)
+          m_value = fnv1a_append_bytes<>(m_value, string[i]);
+      }
+
       // Method for calculating hash at runtime. Accepts
       // any object with range properties.
       template <concepts::hashable Ty>
@@ -1260,8 +1272,8 @@ namespace shadow {
       template <typename CharTy>
       [[nodiscard]] constexpr ValTy fnv1a_append_bytes(ValTy value,
                                                        const CharTy byte) const noexcept {
-        const auto lowercase_byte = case_sensitive ? byte : to_lower(byte);
-        value ^= static_cast<ValTy>(lowercase_byte);
+        const auto byte_to_hash = Opts.case_sensitive ? byte : to_lower(byte);
+        value ^= static_cast<ValTy>(byte_to_hash);
         value *= FNV_prime;
         return value;
       }
@@ -1271,11 +1283,18 @@ namespace shadow {
         return ((c >= 'A' && c <= 'Z') ? (c + 32) : c);
       }
 
-     private:
-     constexpr static ValTy initial_value = seed ?
-      (FNV_offset_basis + static_cast<ValTy>(library_seed)) :
-      FNV_offset_basis;
-      ValTy m_value{ initial_value };
+      constexpr static ValTy initial_value = []() {
+        if constexpr (Opts.seed) {
+          if constexpr (Opts.custom_seed != 0) {
+            return FNV_offset_basis + Opts.custom_seed;
+          } else {
+            return FNV_offset_basis + static_cast<ValTy>(library_seed);
+          }
+        }
+        return FNV_offset_basis;
+      }();
+
+      ValTy m_value{initial_value};
     };
 
     using hash32_t = detail::basic_hash<uint32_t>;

--- a/include/shadowsyscall.hpp
+++ b/include/shadowsyscall.hpp
@@ -1198,7 +1198,9 @@ namespace shadow {
     // basic_hash class provides compile-time and runtime hash
     // computation. Uses FNV-1a hashing algorithm.
     // Case-insensitive by default.
-    template <std::integral ValTy>
+    // cs - case sensitivity
+    // seed - whether to use library seed in case reference fnv is desired.
+    template <std::integral ValTy, bool cs = false, bool seed = true>
     class basic_hash {
      public:
       using underlying_t = ValTy;
@@ -1270,7 +1272,10 @@ namespace shadow {
       }
 
      private:
-      ValTy m_value{FNV_offset_basis + static_cast<ValTy>(library_seed)};
+     constexpr static ValTy initial_value = seed ?
+      (FNV_offset_basis + static_cast<ValTy>(library_seed)) :
+      FNV_offset_basis;
+      ValTy m_value{ initial_value };
     };
 
     using hash32_t = detail::basic_hash<uint32_t>;

--- a/tests/hasher.cpp
+++ b/tests/hasher.cpp
@@ -1,0 +1,21 @@
+#include "gtest/gtest.h"
+#include "shadowsyscall.hpp"
+
+using shadow::detail::basic_hash;
+using shadow::detail::hasher_opts;
+
+template <hasher_opts<uint64_t> Opts>
+using hash64_t = basic_hash<uint64_t, Opts>;
+
+TEST(hasher, basics) {
+  constexpr std::string_view lowercase_string = "my string";
+  constexpr std::string_view mixed_case_string = "My String";
+
+  constexpr auto default_opts = hasher_opts{.seed = false};
+  constexpr auto custom_seed_opts = hasher_opts<uint64_t>{.custom_seed = 100};
+  constexpr auto case_sensitive_opts = hasher_opts{.case_sensitive = true, .seed = false};
+
+  EXPECT_EQ(hash64_t<default_opts>{lowercase_string}, 1704693461258343940ULL);
+  EXPECT_NE(hash64_t<custom_seed_opts>{lowercase_string}, 1704693461258343940ULL);
+  EXPECT_EQ(hash64_t<case_sensitive_opts>{mixed_case_string}, 9354639888599838980ULL);
+}


### PR DESCRIPTION
Commit name was autogenerated by copilot using codespaces.
Reasoning:
I would love to get rid of fnv1a_compile_time.hpp in my projects, and seeing how shadow already provides a base, why not.
Again, very bad at c++ so correct if something is incorrect.

```c
int __fastcall main(int argc, const char **argv, const char **envp)
{


  n0x10 = 0;
  Compiletime_hash = (char *)operator new(0x20u);
  v5 = 0xCBF29CE484222325uLL;
  Compiletime_hash_1 = Compiletime_hash;
  strcpy(Compiletime_hash, "Compiletime_hash");
//    auto k2 = shadow::detail::basic_hash<uint64_t, true, false>();
//    auto k2h = k2(input); (std::string)
  do
  {
    v7 = *Compiletime_hash_1++;
    ++n0x10;
    v5 = 0x100000001B3LL * (v7 ^ v5);
  }
  while ( n0x10 < 0x10 );
  printf("k1: %llx k2h: %llx (should be eq)\n", 0x3A5D898FCDF0C6A8LL, v5);// auto k1 = shadow::detail::basic_hash<uint64_t, true, false>("Compiletime_hash");
  if ( v5 != 0x3A5D898FCDF0C6A8LL )
    __fastfail(9u);                             // passed
  operator delete(Compiletime_hash, 0x20u);
  return 0;
}
```