### PR TITLE
Fix cache being used when there is no cache & add atomic storage for cached alloc/free procedures

### DIFF
--- a/include/shadowsyscall.hpp
+++ b/include/shadowsyscall.hpp
@@ -1111,7 +1111,11 @@ namespace shadow {
   }  // namespace win
 
   namespace detail {
-
+#ifdef SHADOWSYSCALLS_DISABLE_CACHING
+    //still use cache, just not a locking one.
+    inline std::atomic<address_t> cached_alloc_proc{ 0 };
+    inline std::atomic<address_t> cached_free_proc{ 0 };
+#endif
     template <typename Ty>
     struct type_hash {
       auto operator()(const Ty& instance) const noexcept {
@@ -3166,15 +3170,23 @@ namespace shadow {
       void* current_process{reinterpret_cast<void*>(-1)};
       void* base_address = address;
       std::uint64_t region_size = allocation_size;
-
+#ifndef SHADOWSYSCALLS_DISABLE_CACHING
       constexpr auto procedure_name = hash64_t{"NtAllocateVirtualMemory"};
-      auto allocation_procedure = detail::address_cache[procedure_name.get()];
-      if (!allocation_procedure.present()) {
-        allocation_procedure = exported_symbol(procedure_name, "ntdll.dll");
-        detail::address_cache.emplace(procedure_name.get(), allocation_procedure);
+      auto alloc_sym = detail::address_cache[procedure_name.get()];
+      if (!alloc_sym.present()) {
+        alloc_sym = exported_symbol(procedure_name, "ntdll.dll");
+        detail::address_cache.emplace(procedure_name.get(), alloc_sym);
       }
-
-      auto result = allocation_procedure.address().execute<NTSTATUS>(
+      auto allocation_procedure = alloc_sym.address();
+#else 
+      auto allocation_procedure = detail::cached_alloc_proc.load(std::memory_order_acquire);
+      if (!allocation_procedure) {
+        auto addr = exported_symbol(hash64_t{ "NtAllocateVirtualMemory" }, "ntdll.dll").address();
+        detail::cached_alloc_proc.store(addr);
+        allocation_procedure = addr;
+      }
+#endif
+      auto result = allocation_procedure.execute<NTSTATUS>(
           current_process, &base_address, 0ull, &region_size, allocation_t & 0xFFFFFFC0, protect);
       return result >= 0 ? base_address : nullptr;
     }
@@ -3184,22 +3196,30 @@ namespace shadow {
       auto region_size{allocation_size};
       void* base_address = address;
       void* current_process{reinterpret_cast<void*>(-1)};
-
+#ifndef SHADOWSYSCALLS_DISABLE_CACHING
       constexpr auto procedure_name = hash64_t{"NtFreeVirtualMemory"};
-      auto free_procedure = detail::address_cache[procedure_name.get()];
-      if (!free_procedure.present()) {
-        free_procedure = exported_symbol(procedure_name, "ntdll.dll");
-        detail::address_cache.emplace(procedure_name.get(), free_procedure);
+      auto free_sym = detail::address_cache[procedure_name.get()];
+      if (!free_sym.present()) {
+        free_sym = exported_symbol(procedure_name, "ntdll.dll");
+        detail::address_cache.emplace(procedure_name.get(), free_sym);
       }
-
+      auto free_procedure = free_sym.address();
+#else
+      auto free_procedure = detail::cached_free_proc.load(std::memory_order_acquire);
+      if (!free_procedure) {
+        auto addr = exported_symbol(hash64_t{"NtFreeVirtualMemory"}, "ntdll.dll").address();
+        detail::cached_free_proc.store(addr);
+        free_procedure = addr;
+      }
+#endif
       if (((flags & 0xFFFF3FFC) != 0 || (flags & 0x8003) == 0x8000) && allocation_size) {
         result = -0x3FFFFFF3;
       }
 
-      result = free_procedure.address().execute<NTSTATUS>(current_process, &base_address,
+      result = free_procedure.execute<NTSTATUS>(current_process, &base_address,
                                                           &region_size, flags);
       if (result == -0x3FFFFFBB) {
-        result = free_procedure.address().execute<NTSTATUS>(current_process, &base_address,
+        result = free_procedure.execute<NTSTATUS>(current_process, &base_address,
                                                             &region_size, flags);
       }
 


### PR DESCRIPTION
Changes:
1. Fix `detail::address_cache` being used when disabled via macro
2. Add atomic storage for `address_t` as a fallback when cache is disabled.

Reasoning:

-  storing `address_t` should be cheaper than `exported_symbol`

- `std::call_once` uses `__std_init_once_begin_initialize` (->`InitOnceInitialize`) which is counter-productive for a library focused on lazy imports

- `std::atomic` is just sugar, at most we can win 1 `lock cmpxchg` instead of current `xchg` (msvc x64) using [compare_exchange_strong](https://en.cppreference.com/w/cpp/atomic/atomic_ref/compare_exchange.html). This (theoretically) gets rid of `N-1` memory stores when starting `N` threads (e.g. only first thread stores)
To my knowledge, 8 byte store/read on windows x64 are atomic by nature, and situation with concurrent initialization is unavoidable without using mutexes/etc. 

- Worth noting that concurrent initialization is something that doesnt naturally happen very often (for example I start with  SetInformationThread + some amount of sequential NtCreateThreadEx).