### PR TITLE
Add benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,7 @@ if(OMNI_BUILD_TESTS)
   include(CTest)
   add_subdirectory(tests)
 endif()
+
+if(OMNI_BUILD_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()

--- a/benchmarks/.clang-tidy
+++ b/benchmarks/.clang-tidy
@@ -1,0 +1,12 @@
+InheritParentConfig: true
+Checks: >
+  -bugprone-exception-escape,
+  -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
+  -bugprone-unused-local-non-trivial-variable,
+  -google-build-using-namespace,
+  -readability-qualified-auto,
+  -google-global-names-in-headers,
+  -hicpp-special-member-functions,
+  -cppcoreguidelines-special-member-functions,
+  -performance-unnecessary-copy-initialization,

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,55 @@
+message(STATUS "[OMNI] Configuring benchmarks")
+
+include(OmniUseGoogleBenchmark)
+
+set(omni_benchmark_fixture_directory "${CMAKE_CURRENT_BINARY_DIR}/fixtures")
+set(omni_benchmark_fixture_export_counts 16 64 1024 4096)
+set(omni_benchmark_fixture_targets)
+
+function(omni_add_benchmark_export_fixture export_count)
+  set(fixture_source "${omni_benchmark_fixture_directory}/exports_${export_count}.cpp")
+  set(fixture_target "omni_benchmark_exports_${export_count}")
+
+  add_custom_command(
+    OUTPUT "${fixture_source}"
+    COMMAND "${CMAKE_COMMAND}"
+      "-DOUTPUT_FILE:FILEPATH=${fixture_source}"
+      "-DEXPORT_COUNT=${export_count}"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/generate_export_fixture.cmake"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generate_export_fixture.cmake"
+    VERBATIM
+  )
+
+  add_library("${fixture_target}" SHARED "${fixture_source}")
+  target_compile_features("${fixture_target}" PRIVATE cxx_std_23)
+  set_target_properties("${fixture_target}" PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${omni_benchmark_fixture_directory}"
+    LIBRARY_OUTPUT_DIRECTORY "${omni_benchmark_fixture_directory}"
+    ARCHIVE_OUTPUT_DIRECTORY "${omni_benchmark_fixture_directory}"
+  )
+endfunction()
+
+function(omni_add_benchmark source)
+  get_filename_component(benchmark_name "${source}" NAME_WE)
+  set(benchmark_target "omni_benchmark_${benchmark_name}")
+
+  add_executable("${benchmark_target}" "${source}")
+  omni_use_google_benchmark("${benchmark_target}")
+
+  target_compile_features("${benchmark_target}" PRIVATE cxx_std_23)
+  target_link_libraries("${benchmark_target}" PRIVATE omni::omni)
+  target_compile_definitions("${benchmark_target}" PRIVATE OMNI_BENCHMARK_FIXTURE_DIRECTORY="${omni_benchmark_fixture_directory}")
+
+  add_dependencies("${benchmark_target}" ${omni_benchmark_fixture_targets})
+endfunction()
+
+foreach(export_count IN LISTS omni_benchmark_fixture_export_counts)
+  omni_add_benchmark_export_fixture("${export_count}")
+  list(APPEND omni_benchmark_fixture_targets "omni_benchmark_exports_${export_count}")
+endforeach()
+
+file(GLOB omni_benchmark_sources CONFIGURE_DEPENDS *.cpp)
+
+foreach(source IN LISTS omni_benchmark_sources)
+  omni_add_benchmark("${source}")
+endforeach()

--- a/benchmarks/generate_export_fixture.cmake
+++ b/benchmarks/generate_export_fixture.cmake
@@ -1,0 +1,29 @@
+get_filename_component(output_directory "${OUTPUT_FILE}" DIRECTORY)
+file(MAKE_DIRECTORY "${output_directory}")
+
+file(WRITE "${OUTPUT_FILE}" "#include <cstdint>\n\n")
+
+function(omni_format_export_index value output_variable)
+  set(formatted_value "${value}")
+
+  string(LENGTH "${formatted_value}" formatted_value_length)
+
+  while(formatted_value_length LESS 4)
+    set(formatted_value "0${formatted_value}")
+    string(LENGTH "${formatted_value}" formatted_value_length)
+  endwhile()
+
+  set("${output_variable}" "${formatted_value}" PARENT_SCOPE)
+endfunction()
+
+math(EXPR last_export_index "${EXPORT_COUNT} - 1")
+
+foreach(export_index RANGE 0 ${last_export_index})
+  # This keeps generated export names lexicographically ordered
+  # by padding indices to 4 digits (0001, 0002...)
+  omni_format_export_index("${export_index}" export_name_index)
+
+  # Generate mock DLLs with controlled export table size, to keep
+  # benchmark inputs stable and independent from system DLLs
+  file(APPEND "${OUTPUT_FILE}" "extern \"C\" __declspec(dllexport) std::uint32_t omni_bm_export_${export_name_index}() { return ${export_index}u; }\n")
+endforeach()

--- a/benchmarks/named_exports.cpp
+++ b/benchmarks/named_exports.cpp
@@ -1,0 +1,170 @@
+#include <benchmark/benchmark.h>
+
+#include <Windows.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <format>
+#include <string>
+
+#include "omni/hash.hpp"
+#include "omni/module.hpp"
+#include "omni/modules.hpp"
+
+namespace {
+
+  enum class export_position {
+    first,
+    last,
+    missing,
+  };
+
+  class fixture_module {
+   public:
+    explicit fixture_module(std::wstring_view path) noexcept: handle_(LoadLibraryW(path.data())) {}
+
+    fixture_module(const fixture_module&) = delete;
+    fixture_module& operator=(const fixture_module&) = delete;
+
+    fixture_module(fixture_module&& other) noexcept: handle_(std::exchange(other.handle_, nullptr)) {}
+
+    fixture_module& operator=(fixture_module&& other) noexcept {
+      if (this != &other) {
+        reset();
+        handle_ = std::exchange(other.handle_, nullptr);
+      }
+
+      return *this;
+    }
+
+    ~fixture_module() noexcept {
+      reset();
+    }
+
+    [[nodiscard]] HMODULE native_handle() const noexcept {
+      return handle_;
+    }
+
+    [[nodiscard]] bool present() const noexcept {
+      return handle_ != nullptr;
+    }
+
+   private:
+    void reset() noexcept {
+      if (handle_ != nullptr) {
+        FreeLibrary(handle_);
+        handle_ = nullptr;
+      }
+    }
+
+    HMODULE handle_{};
+  };
+
+  [[nodiscard]] std::wstring fixture_module_path(std::int64_t named_export_count) {
+    const auto file_name = std::format("omni_benchmark_exports_{}.dll", named_export_count);
+    const auto path = std::filesystem::path{OMNI_BENCHMARK_FIXTURE_DIRECTORY} / file_name;
+
+    return path.wstring();
+  }
+
+  [[nodiscard]] std::string export_name(std::int64_t named_export_count, export_position position) {
+    std::int64_t export_index{};
+
+    switch (position) {
+    case export_position::first:
+      export_index = 0;
+      break;
+    case export_position::last:
+      export_index = named_export_count - 1;
+      break;
+    case export_position::missing:
+      return "omni_benchmark_export_missing";
+    }
+
+    return std::format("omni_bm_export_{:04}", export_index);
+  }
+
+  [[nodiscard]] std::int64_t expected_scanned_exports(std::int64_t named_export_count, export_position position) noexcept {
+    switch (position) {
+    case export_position::first:
+      return 1;
+    case export_position::last:
+    case export_position::missing:
+      return named_export_count;
+    }
+
+    return named_export_count;
+  }
+
+  [[nodiscard]] bool expected_lookup_result(const auto& exports, const auto& export_iterator,
+    export_position position) noexcept {
+    if (position == export_position::missing) {
+      return export_iterator == exports.end();
+    }
+
+    return export_iterator != exports.end();
+  }
+
+  void module_exports_find(benchmark::State& state, export_position position) {
+    const auto named_export_count = state.range(0);
+    const auto path = fixture_module_path(named_export_count);
+
+    fixture_module loaded_module{path};
+    if (!loaded_module.present()) {
+      state.SkipWithError("failed to load benchmark fixture module");
+      return;
+    }
+
+    const auto module = omni::get_module(omni::address{loaded_module.native_handle()});
+
+    if (!module.present()) {
+      state.SkipWithError("benchmark fixture module was not found by omni");
+      return;
+    }
+
+    const auto exports = module.named_exports();
+    const auto name = export_name(named_export_count, position);
+    const auto name_hash = omni::hash<omni::default_hash>(name);
+    const auto export_iterator = exports.find(name_hash);
+
+    if (!expected_lookup_result(exports, export_iterator, position)) {
+      state.SkipWithError("fixture export lookup produced unexpected result");
+      return;
+    }
+
+    for (auto _ : state) {
+      auto found_export_iterator = exports.find(name_hash);
+      benchmark::DoNotOptimize(found_export_iterator);
+    }
+
+    state.counters["named_exports"] = static_cast<double>(named_export_count);
+    state.counters["expected_scanned_exports"] = static_cast<double>(expected_scanned_exports(named_export_count, position));
+  }
+
+  void module_exports_find_first(benchmark::State& state) {
+    module_exports_find(state, export_position::first);
+  }
+
+  void module_exports_find_last(benchmark::State& state) {
+    module_exports_find(state, export_position::last);
+  }
+
+  void module_exports_find_missing(benchmark::State& state) {
+    module_exports_find(state, export_position::missing);
+  }
+
+  void apply_export_counts(benchmark::Benchmark* benchmark) {
+    benchmark->Arg(16)->Arg(64)->Arg(1024)->Arg(4096)->ArgName("named_exports")->MinWarmUpTime(0.1)->MinTime(0.5);
+  }
+
+  void apply_first_export_count(benchmark::Benchmark* benchmark) {
+    benchmark->Arg(16)->ArgName("named_exports")->MinWarmUpTime(0.1)->MinTime(0.5);
+  }
+
+} // namespace
+
+BENCHMARK(module_exports_find_first)->Apply(apply_first_export_count);
+BENCHMARK(module_exports_find_last)->Apply(apply_export_counts);
+BENCHMARK(module_exports_find_missing)->Apply(apply_export_counts);
+
+BENCHMARK_MAIN();

--- a/cmake/OmniOptions.cmake
+++ b/cmake/OmniOptions.cmake
@@ -2,4 +2,5 @@ include_guard(GLOBAL)
 
 option(OMNI_BUILD_EXAMPLES "Build omni examples" ${PROJECT_IS_TOP_LEVEL})
 option(OMNI_BUILD_TESTS "Build omni tests" ${PROJECT_IS_TOP_LEVEL})
+option(OMNI_BUILD_BENCHMARKS "Build omni benchmarks" ${PROJECT_IS_TOP_LEVEL})
 option(OMNI_DISABLE_EXCEPTIONS "Disable C++ exceptions" OFF)

--- a/cmake/OmniUseGoogleBenchmark.cmake
+++ b/cmake/OmniUseGoogleBenchmark.cmake
@@ -1,0 +1,50 @@
+include_guard(GLOBAL)
+
+include(FetchContent)
+
+function(_omni_try_enable_google_benchmark dependent_target)
+  if(NOT TARGET benchmark::benchmark)
+    find_package(benchmark QUIET)
+  endif()
+
+  if(TARGET benchmark::benchmark)
+    message(STATUS "[OMNI] Using Google benchmark (benchmark::benchmark)")
+  endif()
+endfunction()
+
+function(_omni_enable_bundled_google_benchmark dependent_target)
+  set(google_benchmark_source_dir "${CMAKE_BINARY_DIR}/_deps/google_benchmark-src")
+  set(google_benchmark_binary_dir "${CMAKE_BINARY_DIR}/_deps/google_benchmark-build")
+
+  if(EXISTS "${google_benchmark_source_dir}/CMakeLists.txt")
+    message(STATUS "[OMNI] Using cached Google benchmark source at ${google_benchmark_source_dir}")
+    add_subdirectory("${google_benchmark_source_dir}" "${google_benchmark_binary_dir}")
+    return()
+  endif()
+
+  message(STATUS "[OMNI] Fetching Google benchmark v2.3.1 from git...")
+
+  FetchContent_Declare(google_benchmark
+    GIT_REPOSITORY  https://github.com/google/benchmark
+    GIT_TAG         v1.9.5
+    GIT_SHALLOW     ON
+    UPDATE_DISCONNECTED ON
+  )
+  FetchContent_MakeAvailable(google_benchmark)
+endfunction()
+
+function(omni_use_google_benchmark dependent_target)
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+  set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+  set(BENCHMARK_INSTALL_DOCS OFF CACHE BOOL "" FORCE)
+
+  if(NOT TARGET benchmark::benchmark)
+    _omni_try_enable_google_benchmark(${dependent_target})
+
+    if(NOT TARGET benchmark::benchmark)
+      _omni_enable_bundled_google_benchmark(${dependent_target})
+    endif()
+  endif()
+
+  target_link_libraries(${dependent_target} PRIVATE benchmark::benchmark)
+endfunction()


### PR DESCRIPTION
The results for named exports benchmarks aren't that good right now. The next pull requests will focus on improving the overall library's performance.
```
C:\artem\!cpp\omni\build\benchmarks>"C:/artem/!cpp/omni/build/benchmarks/omni_benchmark_named_exports.exe"
2026-04-30T16:04:00+02:00
Running C:/artem/!cpp/omni/build/benchmarks/omni_benchmark_named_exports.exe
Run on (12 X 3493 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 512 KiB (x6)
  L3 Unified 32768 KiB (x1)
----------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------------------------------------------
module_exports_find_first/named_exports:16/min_time:0.500/min_warmup_time:0.100           24.6 ns         24.3 ns     26352941 expected_scanned_exports=1 named_exports=16
module_exports_find_last/named_exports:16/min_time:0.500/min_warmup_time:0.100             292 ns          292 ns      2357895 expected_scanned_exports=16 named_exports=16
module_exports_find_last/named_exports:64/min_time:0.500/min_warmup_time:0.100            1100 ns         1074 ns       640000 expected_scanned_exports=64 named_exports=64
module_exports_find_last/named_exports:1024/min_time:0.500/min_warmup_time:0.100         16891 ns        16497 ns        40727 expected_scanned_exports=1.024k named_exports=1.024k
module_exports_find_last/named_exports:4096/min_time:0.500/min_warmup_time:0.100         66990 ns        66964 ns        11200 expected_scanned_exports=4.096k named_exports=4.096k
module_exports_find_missing/named_exports:16/min_time:0.500/min_warmup_time:0.100          276 ns          276 ns      2488889 expected_scanned_exports=16 named_exports=16
module_exports_find_missing/named_exports:64/min_time:0.500/min_warmup_time:0.100         1078 ns         1067 ns       746667 expected_scanned_exports=64 named_exports=64
module_exports_find_missing/named_exports:1024/min_time:0.500/min_warmup_time:0.100      16734 ns        16881 ns        40727 expected_scanned_exports=1.024k named_exports=1.024k
module_exports_find_missing/named_exports:4096/min_time:0.500/min_warmup_time:0.100      67966 ns        68359 ns        11200 expected_scanned_exports=4.096k named_exports=4.096k
```