### PR TITLE
Speedup export search hotpaths

### DIFF
--- a/include/omni/detail/export_directory_view.hpp
+++ b/include/omni/detail/export_directory_view.hpp
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string_view>
 
 #include "omni/address.hpp"
 #include "omni/win/directories.hpp"
@@ -71,14 +70,14 @@ namespace omni::detail {
       return export_dir_->base + static_cast<std::uint32_t>(function_index);
     }
 
-    [[nodiscard]] std::string_view name(std::size_t name_index) const noexcept {
+    [[nodiscard]] const char* name(std::size_t name_index) const noexcept {
       if (export_dir_ == nullptr || module_base_ == nullptr || name_index >= names_count()) {
         return {};
       }
 
       auto* names_table = export_dir_->names_table(module_base_.value());
 
-      return std::string_view{module_base_.offset<const char*>(names_table[name_index])};
+      return module_base_.offset<const char*>(names_table[name_index]);
     }
 
     [[nodiscard]] bool is_forwarded(omni::address export_address) const noexcept {

--- a/include/omni/detail/hash_impl.hpp
+++ b/include/omni/detail/hash_impl.hpp
@@ -55,7 +55,8 @@ namespace omni::detail {
     }
 
     template <typename CharT>
-    [[nodiscard]] value_type operator()(const CharT* string) {
+    [[nodiscard]] value_type operator()(const CharT* string) const noexcept {
+      constexpr auto alphabet_last_index = static_cast<value_type>('Z' - 'A');
       T value{FNV_offset_basis};
 
       for (;;) {
@@ -64,8 +65,17 @@ namespace omni::detail {
           return value;
         }
 
-        // Inlining byte appending by hands since it is a critical hotpath
-        value ^= static_cast<value_type>((ch >= static_cast<CharT>('A') && ch <= static_cast<CharT>('Z')) ? (ch + 32) : ch);
+        auto unsigned_ch = static_cast<value_type>(static_cast<std::make_unsigned_t<CharT>>(ch));
+
+        // Keep this as a simple range check and let the optimizer pick branch/cmov/setcc.
+        // Forcing branchless arithmetic lengthens the FNV loop-carried dependency chain
+        const bool is_uppercase = unsigned_ch - static_cast<value_type>('A') <= alphabet_last_index;
+        if (is_uppercase) {
+          unsigned_ch += 32U;
+        }
+
+        // Inlined FNV1A byte append
+        value ^= unsigned_ch;
         value *= FNV_prime;
       }
     }

--- a/include/omni/detail/hash_impl.hpp
+++ b/include/omni/detail/hash_impl.hpp
@@ -54,6 +54,20 @@ namespace omni::detail {
       return value;
     }
 
+    template <typename CharT>
+    [[nodiscard]] value_type operator()(const CharT* string) {
+      T value{FNV_offset_basis};
+
+      for (;;) {
+        const auto ch = *string++;
+        if (ch == static_cast<CharT>('\0')) {
+          return value;
+        }
+
+        value = fnv1a_append_bytes<>(value, ch);
+      }
+    }
+
     [[nodiscard]] value_type value() const {
       return value_;
     }

--- a/include/omni/detail/hash_impl.hpp
+++ b/include/omni/detail/hash_impl.hpp
@@ -64,7 +64,9 @@ namespace omni::detail {
           return value;
         }
 
-        value = fnv1a_append_bytes<>(value, ch);
+        // Inlining byte appending by hands since it is a critical hotpath
+        value ^= static_cast<value_type>((ch >= static_cast<CharT>('A') && ch <= static_cast<CharT>('Z')) ? (ch + 32) : ch);
+        value *= FNV_prime;
       }
     }
 

--- a/include/omni/hash.hpp
+++ b/include/omni/hash.hpp
@@ -29,6 +29,11 @@ namespace omni {
     return T{}(object);
   }
 
+  template <typename T, typename CharT>
+  [[nodiscard]] constexpr auto hash(const CharT* string) {
+    return T{}(string);
+  }
+
   namespace literals {
     consteval omni::fnv1a32 operator""_fnv1a32(const char* str, std::size_t len) noexcept {
       return {std::string_view{str, len}};

--- a/include/omni/named_exports.hpp
+++ b/include/omni/named_exports.hpp
@@ -177,15 +177,15 @@ namespace omni {
     }
 
    private:
-    template <typename Hash>
-    [[nodiscard]] iterator find_by_hashed_name(Hash export_name_hash) const noexcept {
+    template <typename Hasher>
+    [[nodiscard]] iterator find_by_hashed_name(Hasher export_name_hash) const noexcept {
       if (directory() == nullptr) {
         return end();
       }
 
       for (std::size_t i{}; i < size(); ++i) {
-        std::string_view export_name_str = export_dir_view_.name(i);
-        if (export_name_hash == omni::hash<Hash>(export_name_str)) {
+        const char* export_name = export_dir_view_.name(i);
+        if (export_name_hash == omni::hash<Hasher>(export_name)) {
           return {export_dir_view_, i};
         }
       }

--- a/include/omni/named_exports.hpp
+++ b/include/omni/named_exports.hpp
@@ -59,15 +59,15 @@ namespace omni {
       iterator& operator=(iterator&&) = default;
 
       iterator(detail::export_directory_view export_dir_view, std::size_t index) noexcept
-        : export_dir_view_(export_dir_view), index_(index) {
-        update_current_export();
-      }
+        : export_dir_view_(export_dir_view), index_(index) {}
 
       [[nodiscard]] reference operator*() const noexcept {
+        ensure_current_export();
         return current_export_;
       }
 
       [[nodiscard]] pointer operator->() const noexcept {
+        ensure_current_export();
         return &current_export_;
       }
 
@@ -76,6 +76,7 @@ namespace omni {
           export_dir_view_ = other.export_dir_view_;
           index_ = other.index_;
           current_export_ = other.current_export_;
+          current_export_ready_ = other.current_export_ready_;
         }
 
         return *this;
@@ -86,7 +87,7 @@ namespace omni {
           ++index_;
         }
 
-        update_current_export();
+        current_export_ready_ = false;
         return *this;
       }
 
@@ -101,7 +102,7 @@ namespace omni {
           --index_;
         }
 
-        update_current_export();
+        current_export_ready_ = false;
         return *this;
       }
 
@@ -120,15 +121,21 @@ namespace omni {
       }
 
      private:
-      void update_current_export() noexcept {
+      void ensure_current_export() const noexcept {
+        if (current_export_ready_) {
+          return;
+        }
+
         if (!export_dir_view_.present() || index_ >= export_dir_view_.names_count()) {
           current_export_ = value_type{};
+          current_export_ready_ = true;
           return;
         }
 
         const auto function_index = export_dir_view_.function_index(index_);
         if (function_index == detail::export_directory_view::npos) {
           current_export_ = value_type{};
+          current_export_ready_ = true;
           return;
         }
 
@@ -143,11 +150,14 @@ namespace omni {
         if (export_dir_view_.is_forwarded(export_address)) {
           current_export_.forwarder_string = forwarder_string::parse(export_address.ptr<const char>());
         }
+
+        current_export_ready_ = true;
       }
 
       detail::export_directory_view export_dir_view_;
       std::size_t index_{0};
       mutable value_type current_export_{};
+      mutable bool current_export_ready_{false};
     };
 
     static_assert(std::bidirectional_iterator<iterator>);
@@ -191,10 +201,6 @@ namespace omni {
       }
 
       return end();
-    }
-
-    [[nodiscard]] omni::address module_base() const noexcept {
-      return export_dir_view_.module_base();
     }
 
     detail::export_directory_view export_dir_view_;


### PR DESCRIPTION
### 1. Speedup search hotpath by ~17% from replacing string_view by const char*
24.6ns to 20.7ns for first export (in mean values on the same machine)
removing std::string_view from this hot path got rid from the silent std::strlen call in std::string_view constructor, so we got rid from one full O(n) loop.
now we're hashing every symbol of passed const char* until '\0' is encountered

### 2. ~4%+ speedup for const char* runtime hasher
good old inline-by-hand method is working as expected

### 3. ~4.6% speedup from unsigned arithmetic
19.9ns to 18.9ns for first export (in mean values on the same machine)
replaced 2 comparisons with single comparison via unsigned arithmethic, which gives compiler a hint for better optimization path

### 4. ~25.6% speedup from switching to lazy iterator
18.9ns to 14.6ns for first export (in mean values on the same machine)

---
#### UPD 
The performance gains aren't scaling as good as we'd like across many exports. Searching for a non-existent export among 4096 exports was ~19% faster. On average, on my machine, this translates to a reduction from 67966ns to 56239ns. Well, ~19% is better than nothing 😁 :

```
C:\artem\!cpp\omni\build\benchmarks>"C:/artem/!cpp/omni/build/benchmarks/omni_benchmark_named_exports.exe"
2026-05-01T21:25:57+02:00
Running C:/artem/!cpp/omni/build/benchmarks/omni_benchmark_named_exports.exe
Run on (12 X 3493 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 512 KiB (x6)
  L3 Unified 32768 KiB (x1)
----------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------------------------------------------
module_exports_find_missing/named_exports:16/min_time:0.500/min_warmup_time:0.100          228 ns          225 ns      2986667 expected_scanned_exports=16 named_exports=16
module_exports_find_missing/named_exports:64/min_time:0.500/min_warmup_time:0.100          910 ns          900 ns       746667 expected_scanned_exports=64 named_exports=64
module_exports_find_missing/named_exports:1024/min_time:0.500/min_warmup_time:0.100      14298 ns        14439 ns        49778 expected_scanned_exports=1.024k named_exports=1.024k
module_exports_find_missing/named_exports:4096/min_time:0.500/min_warmup_time:0.100      56239 ns        56250 ns        10000 expected_scanned_exports=4.096k named_exports=4.096k
```