### PR TITLE
Redesign omni::ntstatus API

### DIFF
--- a/examples/status.cpp
+++ b/examples/status.cpp
@@ -9,7 +9,6 @@
 
 namespace {
 
-  using named_ntstatus = std::pair<std::string_view, omni::ntstatus>;
   using named_status = std::pair<std::string_view, omni::status>;
 
   [[nodiscard]] std::string_view to_string(omni::severity severity) {
@@ -37,12 +36,6 @@ namespace {
       static_cast<std::uint16_t>(status.code()));
   }
 
-  [[nodiscard]] named_status make_named_status(named_ntstatus item) {
-    omni::status status{};
-    status = item.second;
-    return {item.first, status};
-  }
-
   [[nodiscard]] bool is_failure_status(const named_status& item) {
     return !item.second.is_success();
   }
@@ -51,23 +44,21 @@ namespace {
 
 int main() {
   constexpr std::array cases{
-    named_ntstatus{"success", omni::ntstatus::success},
-    named_ntstatus{"timeout", omni::ntstatus::timeout},
-    named_ntstatus{"no_more_entries", omni::ntstatus::no_more_entries},
-    named_ntstatus{"access_denied", omni::ntstatus::access_denied},
+    named_status{"success", omni::ntstatus::success},
+    named_status{"timeout", omni::ntstatus::timeout},
+    named_status{"no_more_entries", omni::ntstatus::no_more_entries},
+    named_status{"access_denied", omni::ntstatus::access_denied},
   };
 
   std::println("NTSTATUS decoding helpers:");
-  for (auto [label, code] : cases) {
-    omni::status status{};
-    status = code;
+  for (auto [label, status] : cases) {
     print_status(label, status);
   }
 
   std::println();
 
   std::println("Ranges make it easy to focus on the failure cases:");
-  auto failure_cases = cases | std::views::transform(make_named_status) | std::views::filter(is_failure_status);
+  auto failure_cases = cases | std::views::filter(is_failure_status);
   for (auto [label, status] : failure_cases) {
     print_status(label, status);
   }

--- a/include/omni/status.hpp
+++ b/include/omni/status.hpp
@@ -3,8 +3,6 @@
 #include <compare>
 #include <cstdint>
 #include <format>
-#include <type_traits>
-#include <utility>
 
 namespace omni {
 
@@ -71,126 +69,6 @@ namespace omni {
     maximum_value = 0xED,
   };
 
-  enum class ntstatus : std::int32_t {
-    success = static_cast<std::int32_t>(0x00000000),
-    pending = static_cast<std::int32_t>(0x00000103),
-    timeout = static_cast<std::int32_t>(0x00000102),
-    more_entries = static_cast<std::int32_t>(0x00000105),
-    no_more_entries = static_cast<std::int32_t>(0x8000001A),
-    no_more_files = static_cast<std::int32_t>(0x80000006),
-    buffer_overflow = static_cast<std::int32_t>(0x80000005),
-
-    unsuccessful = static_cast<std::int32_t>(0xC0000001),
-    not_implemented = static_cast<std::int32_t>(0xC0000002),
-    not_supported = static_cast<std::int32_t>(0xC00000BB),
-    invalid_info_class = static_cast<std::int32_t>(0xC0000003),
-    info_length_mismatch = static_cast<std::int32_t>(0xC0000004),
-    invalid_handle = static_cast<std::int32_t>(0xC0000008),
-    invalid_parameter = static_cast<std::int32_t>(0xC000000D),
-    invalid_parameter_mix = static_cast<std::int32_t>(0xC0000030),
-    invalid_parameter_1 = static_cast<std::int32_t>(0xC00000EF),
-    invalid_parameter_2 = static_cast<std::int32_t>(0xC00000F0),
-    invalid_parameter_3 = static_cast<std::int32_t>(0xC00000F1),
-    invalid_parameter_4 = static_cast<std::int32_t>(0xC00000F2),
-    invalid_parameter_5 = static_cast<std::int32_t>(0xC00000F3),
-    invalid_parameter_6 = static_cast<std::int32_t>(0xC00000F4),
-    invalid_parameter_7 = static_cast<std::int32_t>(0xC00000F5),
-    invalid_parameter_8 = static_cast<std::int32_t>(0xC00000F6),
-    invalid_parameter_9 = static_cast<std::int32_t>(0xC00000F7),
-    invalid_parameter_10 = static_cast<std::int32_t>(0xC00000F8),
-    invalid_parameter_11 = static_cast<std::int32_t>(0xC00000F9),
-    invalid_parameter_12 = static_cast<std::int32_t>(0xC00000FA),
-    access_denied = static_cast<std::int32_t>(0xC0000022),
-    object_type_mismatch = static_cast<std::int32_t>(0xC0000024),
-    invalid_device_request = static_cast<std::int32_t>(0xC0000010),
-    illegal_instruction = static_cast<std::int32_t>(0xC000001D),
-    noncontinuable_exception = static_cast<std::int32_t>(0xC0000025),
-    invalid_disposition = static_cast<std::int32_t>(0xC0000026),
-    access_violation = static_cast<std::int32_t>(0xC0000005),
-    in_page_error = static_cast<std::int32_t>(0xC0000006),
-    buffer_too_small = static_cast<std::int32_t>(0xC0000023),
-
-    no_memory = static_cast<std::int32_t>(0xC0000017),
-    conflicting_addresses = static_cast<std::int32_t>(0xC0000018),
-    not_mapped_view = static_cast<std::int32_t>(0xC0000019),
-    unable_to_free_vm = static_cast<std::int32_t>(0xC000001A),
-    unable_to_delete_section = static_cast<std::int32_t>(0xC000001B),
-    invalid_view_size = static_cast<std::int32_t>(0xC000001F),
-    invalid_file_for_section = static_cast<std::int32_t>(0xC0000020),
-    already_committed = static_cast<std::int32_t>(0xC0000021),
-    unable_to_decommit_vm = static_cast<std::int32_t>(0xC000002C),
-    not_committed = static_cast<std::int32_t>(0xC000002D),
-    invalid_page_protection = static_cast<std::int32_t>(0xC0000045),
-    memory_not_allocated = static_cast<std::int32_t>(0xC00000A0),
-
-    no_such_device = static_cast<std::int32_t>(0xC000000E),
-    no_such_file = static_cast<std::int32_t>(0xC000000F),
-    end_of_file = static_cast<std::int32_t>(0xC0000011),
-    wrong_volume = static_cast<std::int32_t>(0xC0000012),
-    no_media_in_device = static_cast<std::int32_t>(0xC0000013),
-    unrecognized_media = static_cast<std::int32_t>(0xC0000014),
-    nonexistent_sector = static_cast<std::int32_t>(0xC0000015),
-    object_name_invalid = static_cast<std::int32_t>(0xC0000033),
-    object_name_not_found = static_cast<std::int32_t>(0xC0000034),
-    object_name_collision = static_cast<std::int32_t>(0xC0000035),
-    object_path_invalid = static_cast<std::int32_t>(0xC0000039),
-    object_path_not_found = static_cast<std::int32_t>(0xC000003A),
-    object_path_syntax_bad = static_cast<std::int32_t>(0xC000003B),
-    sharing_violation = static_cast<std::int32_t>(0xC0000043),
-    delete_pending = static_cast<std::int32_t>(0xC0000056),
-    file_is_a_directory = static_cast<std::int32_t>(0xC00000BA),
-    file_renamed = static_cast<std::int32_t>(0xC00000D5),
-    disk_full = static_cast<std::int32_t>(0xC000007F),
-    crc_error = static_cast<std::int32_t>(0xC000003F),
-    media_write_protected = static_cast<std::int32_t>(0xC00000A2),
-
-    procedure_not_found = static_cast<std::int32_t>(0xC000007A),
-    invalid_image_format = static_cast<std::int32_t>(0xC000007B),
-    dll_not_found = static_cast<std::int32_t>(0xC0000135),
-    ordinal_not_found = static_cast<std::int32_t>(0xC0000138),
-    entrypoint_not_found = static_cast<std::int32_t>(0xC0000139),
-    image_not_at_base = static_cast<std::int32_t>(0x40000003),
-    object_name_exists = static_cast<std::int32_t>(0x40000000),
-
-    thread_is_terminating = static_cast<std::int32_t>(0xC000004B),
-    suspend_count_exceeded = static_cast<std::int32_t>(0xC000004A),
-    process_not_in_job = static_cast<std::int32_t>(0x00000123),
-    process_in_job = static_cast<std::int32_t>(0x00000124),
-
-    invalid_owner = static_cast<std::int32_t>(0xC000005A),
-    invalid_primary_group = static_cast<std::int32_t>(0xC000005B),
-    no_impersonation_token = static_cast<std::int32_t>(0xC000005C),
-    cant_disable_mandatory = static_cast<std::int32_t>(0xC000005D),
-    no_logon_servers = static_cast<std::int32_t>(0xC000005E),
-    no_such_logon_session = static_cast<std::int32_t>(0xC000005F),
-    no_such_privilege = static_cast<std::int32_t>(0xC0000060),
-    privilege_not_held = static_cast<std::int32_t>(0xC0000061),
-    invalid_account_name = static_cast<std::int32_t>(0xC0000062),
-    user_exists = static_cast<std::int32_t>(0xC0000063),
-    no_such_user = static_cast<std::int32_t>(0xC0000064),
-    group_exists = static_cast<std::int32_t>(0xC0000065),
-    no_such_group = static_cast<std::int32_t>(0xC0000066),
-    member_in_group = static_cast<std::int32_t>(0xC0000067),
-    member_not_in_group = static_cast<std::int32_t>(0xC0000068),
-    wrong_password = static_cast<std::int32_t>(0xC000006A),
-    logon_failure = static_cast<std::int32_t>(0xC000006D),
-    account_disabled = static_cast<std::int32_t>(0xC0000072),
-    not_all_assigned = static_cast<std::int32_t>(0x00000106),
-    some_not_mapped = static_cast<std::int32_t>(0x00000107),
-
-    port_connection_refused = static_cast<std::int32_t>(0xC0000041),
-    port_disconnected = static_cast<std::int32_t>(0xC0000037),
-    invalid_port_handle = static_cast<std::int32_t>(0xC0000042),
-    invalid_port_attributes = static_cast<std::int32_t>(0xC000002E),
-    port_message_too_long = static_cast<std::int32_t>(0xC000002F),
-    pipe_disconnected = static_cast<std::int32_t>(0xC00000B0),
-    io_timeout = static_cast<std::int32_t>(0xC00000B5),
-    already_disconnected = static_cast<std::int32_t>(0x80000025),
-
-    notify_cleanup = static_cast<std::int32_t>(0x0000010B),
-    notify_enum_dir = static_cast<std::int32_t>(0x0000010C),
-  };
-
   struct status {
     using value_type = std::int32_t;
 
@@ -201,25 +79,13 @@ namespace omni {
       return *this;
     }
 
-    status& operator=(const ntstatus& status) noexcept {
-      value = static_cast<std::int32_t>(status);
-      return *this;
-    }
-
     [[nodiscard]] constexpr bool operator==(std::int32_t val) const noexcept {
       return value == val;
-    }
-
-    [[nodiscard]] constexpr bool operator==(ntstatus status) const noexcept {
-      return value == static_cast<std::int32_t>(status);
     }
 
     [[nodiscard]] constexpr auto operator<=>(const status& other) const noexcept = default;
     [[nodiscard]] constexpr std::strong_ordering operator<=>(std::int32_t val) const noexcept {
       return value <=> val;
-    }
-    [[nodiscard]] constexpr std::strong_ordering operator<=>(ntstatus status) const noexcept {
-      return value <=> static_cast<std::int32_t>(status);
     }
 
     [[nodiscard]] constexpr bool is_success() const noexcept {
@@ -274,18 +140,131 @@ namespace omni {
     constexpr static std::uint32_t code_mask = 0xFFFFU;
   };
 
+  namespace ntstatus {
+    [[maybe_unused]] constexpr inline omni::status success{static_cast<std::int32_t>(0x00000000)};
+    [[maybe_unused]] constexpr inline omni::status pending{static_cast<std::int32_t>(0x00000103)};
+    [[maybe_unused]] constexpr inline omni::status timeout{static_cast<std::int32_t>(0x00000102)};
+    [[maybe_unused]] constexpr inline omni::status more_entries{static_cast<std::int32_t>(0x00000105)};
+    [[maybe_unused]] constexpr inline omni::status no_more_entries{static_cast<std::int32_t>(0x8000001A)};
+    [[maybe_unused]] constexpr inline omni::status no_more_files{static_cast<std::int32_t>(0x80000006)};
+    [[maybe_unused]] constexpr inline omni::status buffer_overflow{static_cast<std::int32_t>(0x80000005)};
+
+    [[maybe_unused]] constexpr inline omni::status unsuccessful{static_cast<std::int32_t>(0xC0000001)};
+    [[maybe_unused]] constexpr inline omni::status not_implemented{static_cast<std::int32_t>(0xC0000002)};
+    [[maybe_unused]] constexpr inline omni::status not_supported{static_cast<std::int32_t>(0xC00000BB)};
+    [[maybe_unused]] constexpr inline omni::status invalid_info_class{static_cast<std::int32_t>(0xC0000003)};
+    [[maybe_unused]] constexpr inline omni::status info_length_mismatch{static_cast<std::int32_t>(0xC0000004)};
+    [[maybe_unused]] constexpr inline omni::status invalid_handle{static_cast<std::int32_t>(0xC0000008)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter{static_cast<std::int32_t>(0xC000000D)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_mix{static_cast<std::int32_t>(0xC0000030)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_1{static_cast<std::int32_t>(0xC00000EF)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_2{static_cast<std::int32_t>(0xC00000F0)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_3{static_cast<std::int32_t>(0xC00000F1)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_4{static_cast<std::int32_t>(0xC00000F2)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_5{static_cast<std::int32_t>(0xC00000F3)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_6{static_cast<std::int32_t>(0xC00000F4)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_7{static_cast<std::int32_t>(0xC00000F5)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_8{static_cast<std::int32_t>(0xC00000F6)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_9{static_cast<std::int32_t>(0xC00000F7)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_10{static_cast<std::int32_t>(0xC00000F8)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_11{static_cast<std::int32_t>(0xC00000F9)};
+    [[maybe_unused]] constexpr inline omni::status invalid_parameter_12{static_cast<std::int32_t>(0xC00000FA)};
+    [[maybe_unused]] constexpr inline omni::status access_denied{static_cast<std::int32_t>(0xC0000022)};
+    [[maybe_unused]] constexpr inline omni::status object_type_mismatch{static_cast<std::int32_t>(0xC0000024)};
+    [[maybe_unused]] constexpr inline omni::status invalid_device_request{static_cast<std::int32_t>(0xC0000010)};
+    [[maybe_unused]] constexpr inline omni::status illegal_instruction{static_cast<std::int32_t>(0xC000001D)};
+    [[maybe_unused]] constexpr inline omni::status noncontinuable_exception{static_cast<std::int32_t>(0xC0000025)};
+    [[maybe_unused]] constexpr inline omni::status invalid_disposition{static_cast<std::int32_t>(0xC0000026)};
+    [[maybe_unused]] constexpr inline omni::status access_violation{static_cast<std::int32_t>(0xC0000005)};
+    [[maybe_unused]] constexpr inline omni::status in_page_error{static_cast<std::int32_t>(0xC0000006)};
+    [[maybe_unused]] constexpr inline omni::status buffer_too_small{static_cast<std::int32_t>(0xC0000023)};
+
+    [[maybe_unused]] constexpr inline omni::status no_memory{static_cast<std::int32_t>(0xC0000017)};
+    [[maybe_unused]] constexpr inline omni::status conflicting_addresses{static_cast<std::int32_t>(0xC0000018)};
+    [[maybe_unused]] constexpr inline omni::status not_mapped_view{static_cast<std::int32_t>(0xC0000019)};
+    [[maybe_unused]] constexpr inline omni::status unable_to_free_vm{static_cast<std::int32_t>(0xC000001A)};
+    [[maybe_unused]] constexpr inline omni::status unable_to_delete_section{static_cast<std::int32_t>(0xC000001B)};
+    [[maybe_unused]] constexpr inline omni::status invalid_view_size{static_cast<std::int32_t>(0xC000001F)};
+    [[maybe_unused]] constexpr inline omni::status invalid_file_for_section{static_cast<std::int32_t>(0xC0000020)};
+    [[maybe_unused]] constexpr inline omni::status already_committed{static_cast<std::int32_t>(0xC0000021)};
+    [[maybe_unused]] constexpr inline omni::status unable_to_decommit_vm{static_cast<std::int32_t>(0xC000002C)};
+    [[maybe_unused]] constexpr inline omni::status not_committed{static_cast<std::int32_t>(0xC000002D)};
+    [[maybe_unused]] constexpr inline omni::status invalid_page_protection{static_cast<std::int32_t>(0xC0000045)};
+    [[maybe_unused]] constexpr inline omni::status memory_not_allocated{static_cast<std::int32_t>(0xC00000A0)};
+
+    [[maybe_unused]] constexpr inline omni::status no_such_device{static_cast<std::int32_t>(0xC000000E)};
+    [[maybe_unused]] constexpr inline omni::status no_such_file{static_cast<std::int32_t>(0xC000000F)};
+    [[maybe_unused]] constexpr inline omni::status end_of_file{static_cast<std::int32_t>(0xC0000011)};
+    [[maybe_unused]] constexpr inline omni::status wrong_volume{static_cast<std::int32_t>(0xC0000012)};
+    [[maybe_unused]] constexpr inline omni::status no_media_in_device{static_cast<std::int32_t>(0xC0000013)};
+    [[maybe_unused]] constexpr inline omni::status unrecognized_media{static_cast<std::int32_t>(0xC0000014)};
+    [[maybe_unused]] constexpr inline omni::status nonexistent_sector{static_cast<std::int32_t>(0xC0000015)};
+    [[maybe_unused]] constexpr inline omni::status object_name_invalid{static_cast<std::int32_t>(0xC0000033)};
+    [[maybe_unused]] constexpr inline omni::status object_name_not_found{static_cast<std::int32_t>(0xC0000034)};
+    [[maybe_unused]] constexpr inline omni::status object_name_collision{static_cast<std::int32_t>(0xC0000035)};
+    [[maybe_unused]] constexpr inline omni::status object_path_invalid{static_cast<std::int32_t>(0xC0000039)};
+    [[maybe_unused]] constexpr inline omni::status object_path_not_found{static_cast<std::int32_t>(0xC000003A)};
+    [[maybe_unused]] constexpr inline omni::status object_path_syntax_bad{static_cast<std::int32_t>(0xC000003B)};
+    [[maybe_unused]] constexpr inline omni::status sharing_violation{static_cast<std::int32_t>(0xC0000043)};
+    [[maybe_unused]] constexpr inline omni::status delete_pending{static_cast<std::int32_t>(0xC0000056)};
+    [[maybe_unused]] constexpr inline omni::status file_is_a_directory{static_cast<std::int32_t>(0xC00000BA)};
+    [[maybe_unused]] constexpr inline omni::status file_renamed{static_cast<std::int32_t>(0xC00000D5)};
+    [[maybe_unused]] constexpr inline omni::status disk_full{static_cast<std::int32_t>(0xC000007F)};
+    [[maybe_unused]] constexpr inline omni::status crc_error{static_cast<std::int32_t>(0xC000003F)};
+    [[maybe_unused]] constexpr inline omni::status media_write_protected{static_cast<std::int32_t>(0xC00000A2)};
+
+    [[maybe_unused]] constexpr inline omni::status procedure_not_found{static_cast<std::int32_t>(0xC000007A)};
+    [[maybe_unused]] constexpr inline omni::status invalid_image_format{static_cast<std::int32_t>(0xC000007B)};
+    [[maybe_unused]] constexpr inline omni::status dll_not_found{static_cast<std::int32_t>(0xC0000135)};
+    [[maybe_unused]] constexpr inline omni::status ordinal_not_found{static_cast<std::int32_t>(0xC0000138)};
+    [[maybe_unused]] constexpr inline omni::status entrypoint_not_found{static_cast<std::int32_t>(0xC0000139)};
+    [[maybe_unused]] constexpr inline omni::status image_not_at_base{static_cast<std::int32_t>(0x40000003)};
+    [[maybe_unused]] constexpr inline omni::status object_name_exists{static_cast<std::int32_t>(0x40000000)};
+
+    [[maybe_unused]] constexpr inline omni::status thread_is_terminating{static_cast<std::int32_t>(0xC000004B)};
+    [[maybe_unused]] constexpr inline omni::status suspend_count_exceeded{static_cast<std::int32_t>(0xC000004A)};
+    [[maybe_unused]] constexpr inline omni::status process_not_in_job{static_cast<std::int32_t>(0x00000123)};
+    [[maybe_unused]] constexpr inline omni::status process_in_job{static_cast<std::int32_t>(0x00000124)};
+
+    [[maybe_unused]] constexpr inline omni::status invalid_owner{static_cast<std::int32_t>(0xC000005A)};
+    [[maybe_unused]] constexpr inline omni::status invalid_primary_group{static_cast<std::int32_t>(0xC000005B)};
+    [[maybe_unused]] constexpr inline omni::status no_impersonation_token{static_cast<std::int32_t>(0xC000005C)};
+    [[maybe_unused]] constexpr inline omni::status cant_disable_mandatory{static_cast<std::int32_t>(0xC000005D)};
+    [[maybe_unused]] constexpr inline omni::status no_logon_servers{static_cast<std::int32_t>(0xC000005E)};
+    [[maybe_unused]] constexpr inline omni::status no_such_logon_session{static_cast<std::int32_t>(0xC000005F)};
+    [[maybe_unused]] constexpr inline omni::status no_such_privilege{static_cast<std::int32_t>(0xC0000060)};
+    [[maybe_unused]] constexpr inline omni::status privilege_not_held{static_cast<std::int32_t>(0xC0000061)};
+    [[maybe_unused]] constexpr inline omni::status invalid_account_name{static_cast<std::int32_t>(0xC0000062)};
+    [[maybe_unused]] constexpr inline omni::status user_exists{static_cast<std::int32_t>(0xC0000063)};
+    [[maybe_unused]] constexpr inline omni::status no_such_user{static_cast<std::int32_t>(0xC0000064)};
+    [[maybe_unused]] constexpr inline omni::status group_exists{static_cast<std::int32_t>(0xC0000065)};
+    [[maybe_unused]] constexpr inline omni::status no_such_group{static_cast<std::int32_t>(0xC0000066)};
+    [[maybe_unused]] constexpr inline omni::status member_in_group{static_cast<std::int32_t>(0xC0000067)};
+    [[maybe_unused]] constexpr inline omni::status member_not_in_group{static_cast<std::int32_t>(0xC0000068)};
+    [[maybe_unused]] constexpr inline omni::status wrong_password{static_cast<std::int32_t>(0xC000006A)};
+    [[maybe_unused]] constexpr inline omni::status logon_failure{static_cast<std::int32_t>(0xC000006D)};
+    [[maybe_unused]] constexpr inline omni::status account_disabled{static_cast<std::int32_t>(0xC0000072)};
+    [[maybe_unused]] constexpr inline omni::status not_all_assigned{static_cast<std::int32_t>(0x00000106)};
+    [[maybe_unused]] constexpr inline omni::status some_not_mapped{static_cast<std::int32_t>(0x00000107)};
+
+    [[maybe_unused]] constexpr inline omni::status port_connection_refused{static_cast<std::int32_t>(0xC0000041)};
+    [[maybe_unused]] constexpr inline omni::status port_disconnected{static_cast<std::int32_t>(0xC0000037)};
+    [[maybe_unused]] constexpr inline omni::status invalid_port_handle{static_cast<std::int32_t>(0xC0000042)};
+    [[maybe_unused]] constexpr inline omni::status invalid_port_attributes{static_cast<std::int32_t>(0xC000002E)};
+    [[maybe_unused]] constexpr inline omni::status port_message_too_long{static_cast<std::int32_t>(0xC000002F)};
+    [[maybe_unused]] constexpr inline omni::status pipe_disconnected{static_cast<std::int32_t>(0xC00000B0)};
+    [[maybe_unused]] constexpr inline omni::status io_timeout{static_cast<std::int32_t>(0xC00000B5)};
+    [[maybe_unused]] constexpr inline omni::status already_disconnected{static_cast<std::int32_t>(0x80000025)};
+
+    [[maybe_unused]] constexpr inline omni::status notify_cleanup{static_cast<std::int32_t>(0x0000010B)};
+    [[maybe_unused]] constexpr inline omni::status notify_enum_dir{static_cast<std::int32_t>(0x0000010C)};
+  } // namespace ntstatus
+
 } // namespace omni
 
 template <>
 struct std::formatter<omni::status> : std::formatter<std::uint32_t> {
   auto format(const omni::status& status, std::format_context& ctx) const {
     return std::formatter<std::uint32_t>::format(static_cast<std::uint32_t>(status.value), ctx);
-  }
-};
-
-template <>
-struct std::formatter<omni::ntstatus> : std::formatter<std::uint32_t> {
-  auto format(const omni::ntstatus& status, std::format_context& ctx) const {
-    return std::formatter<std::uint32_t>::format(static_cast<std::uint32_t>(status), ctx);
   }
 };

--- a/tests/std_format.cpp
+++ b/tests/std_format.cpp
@@ -1,5 +1,4 @@
 #include <limits>
-#include <utility>
 
 #include "omni/hash.hpp"
 #include "omni/module_export.hpp"
@@ -45,10 +44,6 @@ ut::suite<"std::format"> std_format_suite = [] {
     expect(std::format("{}", omni::address{}) == "0");
     expect(std::format("{}", omni::address{1000}) == "1000");
     expect(std::format("{}", omni::address{max_uintptr_t}) == std::to_string(max_uintptr_t));
-  };
-
-  "formats omni::ntstatus"_test = [] {
-    expect(std::format("{}", omni::ntstatus::access_violation) == "3221225477");
   };
 
   "formats omni::status"_test = [] {


### PR DESCRIPTION
the motivation was that conversion between `omni::status` and `omni::ntstatus` was too noisy. `omni::status` has many restrictions, such as a restriction on creating constructors (to prevent the ABI from treating `omni::status` as a non-POD type and passing a hidden function pointer to the RCX), which is why this problem cannot be solved by simply creating the necessary constructor

new approach completely eliminates the ntstatus enum and declares ntstatus as a namespace containing constants of type omni::status