### PR TITLE
docs: add Portuguese (Brazil) translation (pt-br)

### DIFF
--- a/content/docs/pt-br/allocator.mdx
+++ b/content/docs/pt-br/allocator.mdx
@@ -1,0 +1,55 @@
+---
+title: Alocador
+description: Interface de alocador padrão suportada por NtAllocateVirtualMemory
+---
+
+## Constantes
+
+`omni::mem` contém flags de alocação:
+
+- `commit`
+- `reserve`
+- `commit_reserve`
+- `large_commit`
+- `release`
+
+`omni::mem::page` contém flags de proteção de página:
+
+- `no_access`
+- `read_only`
+- `read_write`
+- `execute`
+- `execute_read`
+- `execute_read_write`
+- `guard`
+- `no_cache`
+- `write_combine`
+
+## `omni::nt_allocator<T, AllocFlags, Protect>`
+
+Um tipo compatível com o alocador padrão do C++ suportado por `NtAllocateVirtualMemory` e `NtFreeVirtualMemory`.
+
+| Método | Propósito |
+| --- | --- |
+| `allocate(n)` | aloca memória para `n` elementos |
+| `allocate(address, n)` | solicita alocação em um endereço específico |
+| `deallocate(ptr, n)` | libera a memória alocada |
+
+O alocador expõe os typedefs comuns de alocadores, `rebind`, operadores de igualdade e `is_always_equal`. Em caso de falha na alocação, ele lança `std::bad_alloc` quando exceções estão ativadas; caso contrário, encerra o programa (terminate).
+
+## Aliases
+
+- `omni::rw_allocator<T>` — memória de leitura/escrita (read/write)
+- `omni::rx_allocator<T>` — memória de execução/leitura (execute/read)
+- `omni::rwx_allocator<T>` — memória de execução/leitura/escrita (execute/read/write)
+
+## Exemplo
+
+```cpp
+auto allocator = omni::rw_allocator<std::byte>{};
+auto* page = allocator.allocate(4096);
+auto view = std::span<std::byte>{page, 4096};
+
+std::ranges::fill(view, std::byte{0});
+allocator.deallocate(page, 4096);
+```

--- a/content/docs/pt-br/api-sets.mdx
+++ b/content/docs/pt-br/api-sets.mdx
@@ -1,0 +1,82 @@
+---
+title: API Sets
+description: Inspecione o esquema de API-sets do Windows através da omni
+---
+
+## Visão Geral
+
+Os API sets do Windows mapeiam nomes de DLLs de contrato para DLLs de implementação. A `omni` expõe o esquema do processo em execução como objetos leves compatíveis com ranges.
+
+## `omni::api_set_host`
+
+Uma entrada de host descreve um mapeamento de implementação.
+
+| Campo ou método | Propósito |
+| --- | --- |
+| `value` | nome da DLL de implementação |
+| `alias` | seletor de alias, vazio para o host padrão |
+| `present()` | verifica se `value` não está vazio |
+| `is_default()` | verifica se `alias` está vazio |
+
+## `omni::api_set_hosts`
+
+Um forward range sobre as entradas de host para um contrato de API-set.
+
+| Método | Propósito |
+| --- | --- |
+| `begin()`, `end()` | itera sobre os hosts |
+| `size()` | quantidade de hosts |
+
+## `omni::api_set`
+
+Representa um contrato de API-set.
+
+| Método | Propósito |
+| --- | --- |
+| `contract_name()` | retorna o nome do contrato |
+| `is_sealed()` | verifica a flag `sealed` do esquema |
+| `hosts()` | retorna `omni::api_set_hosts` |
+| `default_host()` | retorna o host padrão, se presente |
+| `resolve_host(alias = {})` | aplica as regras de resolução de API-set para um alias |
+| `present()`, `operator bool()` | verifica a validade |
+
+## `omni::api_sets`
+
+Um range bidirecional sobre o esquema de API-sets do processo atual.
+
+| Método | Propósito |
+| --- | --- |
+| `begin()`, `end()` | itera sobre os contratos de API-set |
+| `size()` | quantidade de contratos |
+| `find(contract_name_hash)` | localiza um contrato por hash/nome |
+| `find_if(predicate)` | localiza por um predicado |
+
+`omni::get_api_set(contract_name_hash)` é uma função utilitária que retorna um valor `omni::api_set`.
+
+## Exemplo
+
+```cpp
+#include "omni/api_sets.hpp"
+
+#include <print>
+#include <ranges>
+
+int main() {
+  omni::api_sets api_sets{};
+
+  auto api_set = api_sets.find_if([](const omni::api_set& item) {
+    return item.default_host().has_value();
+  });
+
+  if (api_set == api_sets.end()) {
+    return 1;
+  }
+
+  std::println("contrato: {}", api_set->contract_name());
+  std::println("sealed  : {}", api_set->is_sealed());
+
+  for (const auto& host : api_set->hosts() | std::views::take(5)) {
+    std::println("{} -> {}", host.alias.empty() ? L"<default>" : host.alias, host.value);
+  }
+}
+```

--- a/content/docs/pt-br/exports.mdx
+++ b/content/docs/pt-br/exports.mdx
@@ -1,0 +1,76 @@
+---
+title: Exportações
+description: Busca, iteração e resolução de exportações de módulos PE
+---
+
+## Busca por ordinal
+
+`omni::use_ordinal_t` e `omni::use_ordinal` selecionam sobrecargas baseadas em ordinal:
+
+```cpp
+auto exp = omni::get_export(1, L"ntdll.dll", omni::use_ordinal);
+```
+
+## `omni::forwarder_string`
+
+Representa uma string de exportação redirecionada (forwarded export) dividida em partes `module` e `function`.
+
+| Método | Propósito |
+| --- | --- |
+| `parse(string_view)` | analisa a string `module.function` |
+| `is_ordinal()` | verifica se o destino é um ordinal |
+| `to_ordinal()` | converte o destino para um ordinal |
+| `present()` | verifica se ambas as partes não estão vazias |
+
+## `omni::module_export`
+
+| Campo | Significado |
+| --- | --- |
+| `name` | nome da exportação, vazio para exportações apenas por ordinal |
+| `address` | endereço resolvido ou endereço bruto da exportação redirecionada |
+| `ordinal` | ordinal da exportação |
+| `is_forwarded` | indica se a exportação é um redirecionamento (forwarder) |
+| `forwarder_string` | destino redirecionado analisado |
+| `forwarder_api_set` | dados do contrato API-set para redirecionadores de API-set |
+| `module_base` | endereço base do módulo proprietário |
+
+Métodos: `is_ordinal_only()`, `present()` e `operator bool()`. Suporte a formatação via `std::formatter<omni::module_export>`.
+
+## `omni::module_exports`
+
+| Método | Propósito |
+| --- | --- |
+| `size()`, `directory()` | inspeciona metadados da tabela de exportação |
+| `name(index)`, `ordinal(index)`, `address(index)` | lê entradas brutas por índice |
+| `is_export_forwarded(address)` | verifica se um endereço aponta para uma string de redirecionador |
+| `all()` | range sobre todas as exportações |
+| `ordinal()` | range sobre posições de ordinais |
+| `named()` | range sobre exportações nomeadas |
+| `find(export_name_hash)` | busca por nome/hash |
+| `find(ordinal, omni::use_ordinal)` | busca por ordinal |
+| `find_if(predicate)` | busca por predicado |
+
+## Busca livre
+
+`omni::get_export` retorna um `omni::module_export` preenchido ou um valor vazio.
+
+- `omni::get_export(export_name_hash, omni::module module)`
+- `omni::get_export(export_name_hash, module_name_hash)`
+- `omni::get_export(export_name_hash)`
+- `omni::get_export(ordinal, omni::module module, omni::use_ordinal)`
+- `omni::get_export(ordinal, module_name_hash, omni::use_ordinal)`
+
+Redirecionadores (forwarders) são analisados em campos explícitos. Se o módulo de destino estiver carregado, a busca pode resolver o destino final; caso contrário, a exportação retornada permanece legível como dados de redirecionador.
+
+## Exemplo
+
+```cpp
+auto kernel32 = omni::get_module(L"kernel32.dll");
+
+for (const auto& export_entry : kernel32.exports().named() | std::views::take(5)) {
+  std::println("{}", export_entry.name);
+}
+
+auto by_name = kernel32.exports().find("GetCurrentProcessId");
+auto by_ordinal = kernel32.exports().find(1, omni::use_ordinal);
+```

--- a/content/docs/pt-br/index.mdx
+++ b/content/docs/pt-br/index.mdx
@@ -1,0 +1,58 @@
+---
+title: Introdução
+description: API pública de uma biblioteca C++23 header-only para tarefas de baixo nível no Windows
+---
+
+# omni
+
+A `omni` é uma biblioteca C++23 header-only focada em desenvolvimento de baixo nível para Windows: inspeção de módulos e exportações, leitura de esquemas API-set, imports preguiçosos (lazy imports), syscalls, dados compartilhados de usuário, alocadores e hashing em tempo de compilação.
+
+## API Pública
+
+<Cards>
+  <Card title="Início Rápido" href="quick-start" />
+  <Card title="Casos de Uso" href="use-cases" />
+  <Card title="Utilitários" href="utilities" />
+  <Card title="Status" href="status" />
+  <Card title="Módulos" href="modules" />
+  <Card title="Exportações" href="exports" />
+  <Card title="API Sets" href="api-sets" />
+  <Card title="Lazy Import" href="lazy-import" />
+  <Card title="Syscalls" href="syscalls" />
+  <Card title="Shared User Data" href="shared-user-data" />
+  <Card title="Alocador" href="allocator" />
+</Cards>
+
+## Destaques
+
+- acesso à lista do carregador (loader-list) via `omni::modules` compatível com ranges;
+- análise da tabela de exportação PE via `omni::module_exports` e `omni::module_export`;
+- inspeção do esquema API-set via `omni::api_sets` e `omni::api_set`;
+- chamadas WinAPI via `omni::lazy_import` e `omni::lazy_importer`;
+- chamadas a NT syscalls x64 via `omni::syscall` e `omni::syscaller`;
+- acesso a `KUSER_SHARED_DATA` via `omni::shared_user_data()`;
+- hashes fortemente tipados em tempo de compilação com políticas de hash substituíveis;
+- cache interno opcional para lazy imports e IDs de syscall.
+
+## Escopo
+
+As páginas de referência da API documentam entidades públicas individuais. A página de Casos de Uso mostra fluxos de trabalho completos que as combinam. Este site documenta a API pública voltada ao usuário. Cabeçalhos em `omni/detail/*` são detalhes de implementação e não são tratados como contrato suportado.
+
+## Cabeçalhos públicos
+
+- `omni/omni.hpp`
+- `omni/address.hpp`
+- `omni/allocator.hpp`
+- `omni/api_set.hpp`
+- `omni/api_sets.hpp`
+- `omni/concepts.hpp`
+- `omni/error.hpp`
+- `omni/hash.hpp`
+- `omni/lazy_import.hpp`
+- `omni/module.hpp`
+- `omni/module_export.hpp`
+- `omni/module_exports.hpp`
+- `omni/modules.hpp`
+- `omni/shared_user_data.hpp`
+- `omni/status.hpp`
+- `omni/syscall.hpp`

--- a/content/docs/pt-br/lazy-import.mdx
+++ b/content/docs/pt-br/lazy-import.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lazy Import
-description: Resolva e chame exportações WinAPI sem vinculo direto (direct linking)
+description: Resolva e chame exportações WinAPI sem vínculo direto (direct linking)
 ---
 
 ## Visão Geral

--- a/content/docs/pt-br/lazy-import.mdx
+++ b/content/docs/pt-br/lazy-import.mdx
@@ -1,0 +1,81 @@
+---
+title: Lazy Import
+description: Resolva e chame exportações WinAPI sem vinculo direto (direct linking)
+---
+
+## Visão Geral
+
+O lazy import resolve uma exportação no ponto de chamada, evitando que o executável precise ser vinculado diretamente à biblioteca de importação. Você pode usar funções livres simples para chamadas pontuais ou `omni::lazy_importer<T>` para reutilização tipada e acesso a metadados.
+
+## `omni::lazy_importer<T>`
+
+A forma genérica retorna `T`. Especializações de ponteiros de função deduzem os tipos de parâmetros e retorno a partir da assinatura.
+
+### Construtores
+
+- `lazy_importer(export_name_hash)`
+- `lazy_importer(default_hash)`
+- `lazy_importer(export_name_hash, module_name_hash)`
+- `lazy_importer(default_hash, default_hash)`
+
+### Métodos
+
+| Método | Retorno | Propósito |
+| --- | --- | --- |
+| `try_invoke(args...)` | `std::expected<T, std::error_code>` | executa com diagnósticos |
+| `invoke(args...)` | `T` | executa e retorna valor padrão em caso de falha |
+| `operator()(args...)` | `T` | atalho para `invoke` |
+| `module_export()` | `omni::module_export` | inspeciona os metadados da exportação resolvidos |
+
+## `omni::lazy_import`
+
+Sobrecargas livres cobrem os estilos de chamada comuns:
+
+- `omni::lazy_import<T = void>(export_name_hash, args...)`
+- `omni::lazy_import<T = void>(hash_pair, args...)`
+- `omni::lazy_import<F>(export_name_hash, args...)`
+- `omni::lazy_import<F>(hash_pair, args...)`
+- `omni::lazy_import<Func, Hasher>(args...)`
+- `omni::lazy_import<Func>(args...)`
+- `omni::lazy_import<Func, ModuleName, Hasher>(args...)`
+- `omni::lazy_import<Func, ModuleName>(args...)`
+
+## Exemplos
+
+### Importador tipado
+
+```cpp
+using get_module_handle_w_fn = HMODULE(WINAPI*)(LPCWSTR);
+
+auto get_module_handle = omni::lazy_importer<get_module_handle_w_fn>{"GetModuleHandleW"};
+HMODULE kernel32 = get_module_handle(L"kernel32.dll");
+auto export_entry = get_module_handle.module_export();
+```
+
+### Par de exportação e módulo
+
+```cpp
+using get_system_directory_w_fn = UINT(WINAPI*)(LPWSTR, UINT);
+
+auto length = omni::lazy_import<get_system_directory_w_fn>(
+  {"GetSystemDirectoryW", "kernel32.dll"},
+  buffer.data(),
+  static_cast<UINT>(buffer.size())
+);
+```
+
+### Ponteiro de função em tempo de compilação
+
+```cpp
+auto process_id = omni::lazy_import<::GetCurrentProcessId>();
+```
+
+### Tipo de retorno genérico
+
+```cpp
+omni::lazy_import<void>("SetLastError", 0xCAFEU);
+```
+
+## Erros e cache
+
+O `try_invoke()` pode relatar `module_not_loaded`, `export_not_found` ou `forwarder_string_invalid`. A menos que `OMNI_DISABLE_CACHING` esteja definido, as exportações resolvidas são mantidas em cache e entradas obsoletas são atualizadas quando o módulo proprietário não estiver mais carregado.

--- a/content/docs/pt-br/meta.json
+++ b/content/docs/pt-br/meta.json
@@ -1,0 +1,17 @@
+{
+  "title": "Documentação omni",
+  "pages": [
+    "index",
+    "quick-start",
+    "use-cases",
+    "utilities",
+    "status",
+    "modules",
+    "exports",
+    "api-sets",
+    "lazy-import",
+    "syscalls",
+    "shared-user-data",
+    "allocator"
+  ]
+}

--- a/content/docs/pt-br/modules.mdx
+++ b/content/docs/pt-br/modules.mdx
@@ -1,0 +1,64 @@
+---
+title: Módulos
+description: Acesso à lista do carregador (loader list) e módulos carregados através da omni
+---
+
+## `omni::module`
+
+`omni::module` é uma visão leve de uma imagem carregada a partir da lista do carregador do processo.
+
+| Método | Propósito |
+| --- | --- |
+| `entry()`, `loader_entry()` | acessa a entrada subjacente do carregador |
+| `image()` | retorna `win::image*` para acesso aos cabeçalhos PE |
+| `base_address()`, `native_handle()` | retorna o endereço base do módulo |
+| `entry_point()` | retorna o ponto de entrada da imagem (entry point) |
+| `name()`, `wname()` | retorna o nome do módulo em formato ANSI ou wide |
+| `system_path()` | retorna o caminho completo do módulo |
+| `exports()` | retorna `omni::module_exports` |
+| `present()`, `operator bool()` | verifica se a visão do módulo é válida |
+| `matches_name_hash(hash)` | compara com o hash do nome de um módulo |
+
+Suporte a `std::formatter<omni::module>` e saída em stream estão disponíveis para formatação.
+
+## `omni::modules`
+
+`omni::modules` é um range bidirecional sobre a lista do carregador no PEB.
+
+| Método | Propósito |
+| --- | --- |
+| `begin()`, `end()` | itera sobre os módulos carregados |
+| `skip(count = 1)` | ignora as entradas iniciais da lista do carregador |
+| `find(module_name_hash)` | busca pelo hash do nome do módulo |
+| `find(omni::address)` | busca pelo endereço base |
+| `find_if(predicate)` | busca por um predicado personalizado |
+| `contains(...)` | verifica se um módulo está carregado |
+
+## Funções utilitárias
+
+- `omni::base_module()` retorna o módulo da imagem do processo atual.
+- `omni::get_module(module_name_hash)` busca um módulo carregado por nome.
+- `omni::get_module(omni::address)` busca um módulo por endereço base.
+
+A correspondência de nomes aceita tanto `kernel32.dll` quanto `kernel32` quando o nome real do módulo possui o sufixo `.dll`.
+
+## Exemplo
+
+```cpp
+#include "omni/modules.hpp"
+
+#include <print>
+#include <ranges>
+
+int main() {
+  auto self = omni::base_module();
+  auto kernel32 = omni::get_module(L"kernel32.dll");
+
+  std::println("imagem atual: {}", self.name());
+  std::println("kernel32 base: {:#x}", kernel32.base_address().value());
+
+  for (const auto& module : omni::modules{} | std::views::take(5)) {
+    std::println("{}", module.name());
+  }
+}
+```

--- a/content/docs/pt-br/quick-start.mdx
+++ b/content/docs/pt-br/quick-start.mdx
@@ -1,0 +1,76 @@
+---
+title: Início Rápido
+description: Início rápido com a omni e uma visão geral dos principais cenários de uso
+---
+
+## Integração
+
+A `omni` é header-only. Adicione o diretório do projeto no CMake e vincule o target exportado:
+
+```cmake
+add_subdirectory(caminho/para/omni)
+target_link_libraries(seu_target PRIVATE omni::omni)
+```
+
+## Requisitos
+
+- Windows
+- CMake 3.21+
+- Compilador com suporte a C++23
+
+## Exemplo mínimo
+
+```cpp
+#include <Windows.h>
+
+#include "omni/modules.hpp"
+#include "omni/syscall.hpp"
+
+#include <cstdint>
+#include <print>
+
+int main() {
+  auto kernel32 = omni::get_module(L"kernel32.dll");
+  auto yield_status = omni::syscall("NtYieldExecution");
+
+  std::println("módulo  : {}", kernel32.name());
+  std::println("exports : {}", kernel32.exports().size());
+  std::println("yield   : 0x{:08X}", static_cast<std::uint32_t>(yield_status.value));
+}
+```
+
+## Áreas da API
+
+| Área | Entidades principais |
+| --- | --- |
+| Utilitários | `omni::address`, `omni::fnv1a32`, `omni::fnv1a64`, `omni::default_hash`, `omni::error` |
+| Status | `omni::status`, `omni::severity`, `omni::facility`, `omni::ntstatus` |
+| Módulos | `omni::module`, `omni::modules`, `omni::base_module`, `omni::get_module` |
+| Exportações | `omni::module_export`, `omni::module_exports`, `omni::get_export` |
+| API Sets | `omni::api_set`, `omni::api_sets`, `omni::api_set_host`, `omni::get_api_set` |
+| Lazy Import | `omni::lazy_importer`, `omni::lazy_import` |
+| Syscalls | `omni::syscaller`, `omni::syscall`, `omni::default_syscall_id_parser` |
+| Dados Compartilhados | `omni::shared_user_data`, `omni::win::kernel_user_shared_data` |
+| Memória | `omni::nt_allocator`, `omni::rw_allocator`, `omni::rx_allocator`, `omni::rwx_allocator` |
+
+## Compilando exemplos e testes
+
+```bash
+cmake -S . -B build -DOMNI_BUILD_EXAMPLES=ON -DOMNI_BUILD_TESTS=ON
+cmake --build build --config Release
+ctest --test-dir build --output-on-failure -C Release
+```
+
+## Macros de configuração
+
+| Macro | Efeito |
+| --- | --- |
+| `OMNI_DISABLE_CACHING` | desativa os caches internos de lazy-import e IDs de syscall |
+| `OMNI_ENABLE_ERROR_STRINGS` | mantém strings de erro legíveis em compilações de não-debug (Release) |
+| `OMNI_DISABLE_ERROR_STRINGS` | remove strings de erro mesmo em compilações de debug |
+
+## Observações
+
+- a biblioteca é específica para Windows;
+- a API de syscall é destinada a processos x64;
+- sobrecargas cientes de hash aceitam valores de hash fortemente tipados e literais de string que podem ser convertidos em tempo de compilação.

--- a/content/docs/pt-br/shared-user-data.mdx
+++ b/content/docs/pt-br/shared-user-data.mdx
@@ -1,0 +1,56 @@
+---
+title: Shared User Data
+description: Acesso a KUSER_SHARED_DATA através da omni
+---
+
+## `omni::shared_user_data()`
+
+Retorna um ponteiro `omni::win::kernel_user_shared_data*` para o mapeamento fixo de `KUSER_SHARED_DATA` no endereço `0x7ffe0000`.
+
+```cpp
+const auto* shared = omni::shared_user_data();
+```
+
+## `omni::win::kernel_user_shared_data`
+
+Uma estrutura pública que descreve os dados de usuário compartilhados disponíveis para todos os processos.
+
+### Método prático útil
+
+- `system_root()` — retorna um `std::filesystem::path` para `nt_system_root`.
+
+### Campos frequentemente usados
+
+- `nt_major_version`
+- `nt_minor_version`
+- `nt_build_number`
+- `active_processor_count`
+- `active_group_count`
+- `qpc_frequency`
+- `safe_boot_mode`
+- `dbg_secure_boot_enabled`
+- `virtualization_flags`
+
+### Exemplo
+
+```cpp
+const auto* shared = omni::shared_user_data();
+
+std::println("system root: {}", shared->system_root().string());
+std::println("versão     : {}.{} build {}",
+  shared->nt_major_version,
+  shared->nt_minor_version,
+  shared->nt_build_number);
+```
+
+## Tipos públicos adicionais
+
+Os seguintes tipos também são publicamente visíveis em `omni/win/kernel_user_shared_data.hpp`:
+
+- `omni::win::kernel_system_time`
+- `omni::win::nt_product_type`
+- `omni::win::alternative_arch_type`
+- `omni::win::xstate_feature`
+- `omni::win::xstate_configuration`
+
+Estes são úteis caso o usuário queira ler diretamente campos de estruturas de nível mais baixo.

--- a/content/docs/pt-br/status.mdx
+++ b/content/docs/pt-br/status.mdx
@@ -1,0 +1,62 @@
+---
+title: Status
+description: Tipos NTSTATUS e verificações utilitárias na omni
+---
+
+## Enumerações
+
+### `omni::severity`
+
+Classifica os bits mais significativos de um valor NTSTATUS:
+
+- `success`
+- `information`
+- `warning`
+- `error`
+
+### `omni::facility`
+
+Representa o subsistema (facility) de status do NT. O enum inclui grupos comuns como `rpc_runtime`, `io_error_code`, `ntwin32`, `graphics_kernel`, `hypervisor` e `security_core`.
+
+### `omni::ntstatus`
+
+Contém constantes NTSTATUS frequentemente utilizadas, incluindo:
+
+- estados de sucesso e informativos: `success`, `pending`, `more_entries`
+- estados de fim de iteração: `no_more_entries`, `no_more_files`
+- erros de validação e busca: `invalid_parameter`, `object_name_not_found`, `procedure_not_found`
+- erros de acesso e memória: `access_denied`, `access_violation`, `no_memory`
+- erros de módulo e recursos: `dll_not_found`, `not_implemented`, `not_supported`, `unsuccessful`
+
+## `omni::status`
+
+Um wrapper leve sobre o valor bruto `NTSTATUS`.
+
+| API | Propósito |
+| --- | --- |
+| `value` | valor de status bruto `std::int32_t` |
+| `operator=(std::int32_t)` | atribui um valor bruto |
+| `operator=(omni::ntstatus)` | atribui a partir do enum |
+| `is_success()` | verifica se é um status não-negativo (sucesso) |
+| `is_information()` | verifica gravidade informativa |
+| `is_warning()` | verifica gravidade de aviso (warning) |
+| `is_error()` | verifica gravidade de erro |
+| `severity()` | retorna `omni::severity` |
+| `facility()` | retorna `omni::facility` |
+| `code()` | retorna os 16 bits inferiores (código de erro) |
+
+O tipo suporta comparações com inteiros brutos, `omni::ntstatus` e outros valores `omni::status`. Também suporta conversão explícita para `bool` e `std::int32_t`, além de `std::formatter` para `omni::status` e `omni::ntstatus`.
+
+## Exemplo
+
+```cpp
+omni::status result = omni::ntstatus::success;
+
+if (result.is_success()) {
+  std::println("status: 0x{:08X}", static_cast<std::uint32_t>(result.value));
+}
+
+if (result == omni::ntstatus::success) {
+  std::println("sucesso exato");
+}
+```

--- a/content/docs/pt-br/syscalls.mdx
+++ b/content/docs/pt-br/syscalls.mdx
@@ -1,0 +1,74 @@
+---
+title: Syscalls
+description: Resolva IDs de syscall e invoque chamadas de sistema através da omni
+---
+
+## Limitação de plataforma
+
+`omni::syscaller` e `omni::syscall` são exclusivos para arquitetura x64.
+
+## `omni::syscaller<T>`
+
+Um wrapper tipado que encontra uma exportação, extrai o ID da syscall a partir de seu stub, prepara a ponte em shellcode e executa a chamada de sistema.
+
+### Construtores
+
+- `syscaller(export_name_hash, syscall_id_parser parser = default_syscall_id_parser)`
+- `syscaller(default_hash, syscall_id_parser parser = default_syscall_id_parser)`
+
+`syscaller<T>::syscall_id_parser` é o tipo do analisador (parser). O parser padrão é `omni::default_syscall_id_parser(const omni::module_export&)`.
+
+### Métodos
+
+| Método | Retorno | Propósito |
+| --- | --- | --- |
+| `try_invoke(args...)` | `std::expected<T, std::error_code>` | executa com diagnósticos |
+| `invoke(args...)` | `T` | executa e retorna valor padrão em caso de falha |
+| `operator()(args...)` | `T` | atalho para `invoke` |
+
+Especializações de ponteiro de função deduzem argumentos e o tipo de retorno a partir da assinatura da função NT.
+
+## `omni::syscall`
+
+Sobrecargas livres oferecem chamadas pontuais e concisas:
+
+- `omni::syscall<T = omni::status>(export_name_hash, args...)`
+- `omni::syscall<F>(export_name_hash, args...)`
+- `omni::syscall<Func, Hasher>(args...)`
+- `omni::syscall<Func>(args...)`
+
+## Exemplos
+
+```cpp
+auto yield_status = omni::syscall<omni::status>("NtYieldExecution");
+```
+
+```cpp
+using nt_query_info_process_fn = omni::status (*)(HANDLE, ULONG, void*, ULONG, ULONG*);
+
+omni::syscaller<nt_query_info_process_fn> query_process{"NtQueryInformationProcess"};
+auto result = query_process.try_invoke(
+  ::GetCurrentProcess(),
+  0U,
+  &process_info,
+  sizeof(process_info),
+  &return_length
+);
+```
+
+```cpp
+auto status = omni::syscall<nt_query_info_process_fn>(
+  "NtQueryInformationProcess",
+  ::GetCurrentProcess(),
+  0U,
+  &process_info,
+  sizeof(process_info),
+  &return_length
+);
+```
+
+## Erros e observações
+
+O `try_invoke()` pode relatar `export_not_found`, `module_not_loaded` ou `syscall_id_not_found`. O último erro significa que a exportação foi encontrada, mas não correspondeu ao padrão esperado do stub de syscall.
+
+Sobrecargas livres sem `try_*` retornam um valor construído por padrão (default-constructed) em caso de falha. O parser padrão não trata hooks ou stubs modificados por EDR.

--- a/content/docs/pt-br/use-cases.mdx
+++ b/content/docs/pt-br/use-cases.mdx
@@ -1,0 +1,438 @@
+---
+title: Casos de Uso
+description: Tutoriais passo a passo para os principais cenários de uso da omni
+---
+
+# Casos de Uso
+
+Esta página mostra como as APIs públicas se encaixam em fluxos de trabalho reais. Os exemplos são baseados nos programas independentes em `omni-lib/examples`.
+
+## Inspecionar um endereço bruto e chamar código através dele
+
+Use `omni::address` quando precisar de aritmética de ponteiro tipada, visões de range sobre memória bruta, verificações de intervalo de endereço ou invocação via ponteiro de função resolvido.
+
+```cpp
+#include <Windows.h>
+
+#include "omni/address.hpp"
+#include "omni/modules.hpp"
+
+#include <array>
+#include <print>
+#include <ranges>
+#include <span>
+
+int main() {
+  auto values = std::array{1U, 2U, 3U, 4U};
+  auto values_address = omni::address{values};
+  auto view = values_address.span<unsigned>(values.size());
+
+  std::println("base: {:#x}", values_address.value());
+  std::println("segundo: {}", *values_address.offset<const unsigned*>(sizeof(unsigned)));
+
+  for (auto value : view | std::views::transform([](unsigned v) { return v * 10U; })) {
+    std::println("{}", value);
+  }
+
+  auto* kernel32_handle = ::GetModuleHandleW(L"kernel32.dll");
+  auto kernel32 = omni::get_module(L"kernel32.dll");
+  auto get_current_process_id = omni::address{::GetProcAddress(kernel32_handle, "GetCurrentProcessId")};
+
+  auto image_size = kernel32.image()->get_optional_header()->size_image;
+  auto inside = get_current_process_id.is_in_range(
+    kernel32.base_address(),
+    kernel32.base_address().offset(image_size)
+  );
+
+  auto process_id = get_current_process_id.invoke<DWORD>();
+  std::println("dentro de kernel32: {}", inside);
+  std::println("pid: {}", process_id.value_or(0U));
+}
+```
+
+Pontos importantes:
+
+- `span<T>()` é útil quando a memória bruta deve entrar em uma pipeline de ranges;
+- `is_in_range()` combina naturalmente com o endereço base do módulo e o tamanho da imagem;
+- `invoke<T>()` retorna um objeto de resultado, portanto trate o caminho de falha.
+
+Veja também: [Utilitários](utilities), [Módulos](modules).
+
+## Alocar memória virtual com um alocador padrão
+
+Use `omni::nt_allocator` e seus aliases quando uma interface de alocador padrão deve alocar memória via `NtAllocateVirtualMemory`.
+
+```cpp
+#include "omni/allocator.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <numeric>
+#include <ranges>
+#include <span>
+
+int main() {
+  auto allocator = omni::rw_allocator<std::byte>{};
+  auto* page = allocator.allocate(4096);
+  auto page_view = std::span<std::byte>{page, 4096};
+
+  std::ranges::fill(page_view, std::byte{0});
+
+  auto values = std::span<std::uint32_t>{reinterpret_cast<std::uint32_t*>(page), 16};
+  std::ranges::iota(values, 1U);
+
+  for (auto value : values | std::views::transform([](auto v) { return v * v; })) {
+    std::println("{}", value);
+  }
+
+  allocator.deallocate(page, 4096);
+}
+```
+
+Pontos importantes:
+
+- escolha `rw_allocator`, `rx_allocator` ou `rwx_allocator` de acordo com a proteção de página necessária;
+- alinhe cada `allocate()` manual com um `deallocate()`;
+- falha de alocação lança `std::bad_alloc` quando exceções estão ativadas.
+
+Veja também: [Alocador](allocator).
+
+## Inspecionar módulos carregados como um range do C++
+
+Use `omni::modules` para percorrer a lista do carregador do processo, filtrar módulos, encontrar um módulo por nome ou endereço base e inspecionar metadados de módulos.
+
+```cpp
+#include "omni/modules.hpp"
+
+#include <print>
+#include <ranges>
+
+bool is_interesting(const omni::module& module) {
+  return module.matches_name_hash(L"ntdll") || module.matches_name_hash(L"kernel32");
+}
+
+int main() {
+  omni::modules loaded_modules{};
+
+  for (const auto& module : loaded_modules | std::views::filter(is_interesting)) {
+    std::println("{} base={:#x} exports={}",
+      module.name(),
+      module.base_address().value(),
+      module.exports().size());
+  }
+
+  auto kernel32 = loaded_modules.find(L"kernel32");
+  if (kernel32 != loaded_modules.end()) {
+    std::println("caminho: {}", kernel32->system_path().string());
+    std::println("contém a base: {}", loaded_modules.contains(kernel32->base_address()));
+  }
+}
+```
+
+Pontos importantes:
+
+- a busca por nome de módulo aceita nomes com ou sem o sufixo `.dll`;
+- `skip()` pode ser usado se você quiser ignorar a entrada da imagem do processo;
+- `omni::base_module()` é a maneira mais rápida de obter a imagem atual.
+
+Veja também: [Módulos](modules), [Exportações](exports).
+
+## Inspecionar um módulo e suas exportações
+
+Use `omni::module` e `omni::module_exports` quando precisar de metadados PE e iteração sobre a tabela de exportação.
+
+```cpp
+#include "omni/modules.hpp"
+
+#include <print>
+#include <ranges>
+
+int main() {
+  auto self = omni::base_module();
+  auto kernel32 = omni::get_module(L"kernel32.dll");
+
+  auto* optional_header = self.image()->get_optional_header();
+  std::println("imagem: {}", self.name());
+  std::println("entry : {:#x}", self.entry_point().value());
+  std::println("tamanho: {}", optional_header->size_image);
+
+  for (const auto& export_entry : kernel32.exports().named() | std::views::take(5)) {
+    std::println("{}", export_entry.name);
+  }
+}
+```
+
+Pontos importantes:
+
+- `image()` expõe auxiliares públicos da imagem PE;
+- `exports().named()` fornece exportações nomeadas como um range comum;
+- verifique `present()` ou `operator bool()` quando a busca puder falhar.
+
+Veja também: [Módulos](modules), [Exportações](exports).
+
+## Resolver exportações por nome, ordinal e redirecionador (forwarder)
+
+Use `module_exports` quando precisar de acesso detalhado à tabela de exportação, incluindo entradas apenas por ordinal e exportações redirecionadas.
+
+```cpp
+#include "omni/module_exports.hpp"
+#include "omni/modules.hpp"
+
+#include <print>
+#include <ranges>
+
+int main() {
+  auto shlwapi = omni::get_module(L"shlwapi.dll");
+  auto exports = shlwapi.exports();
+
+  for (const auto& entry : exports.named() | std::views::take(10)) {
+    std::println("{:>4} {}", entry.ordinal, entry.name);
+  }
+
+  auto by_name = exports.find("SHUnicodeToAnsiCP");
+  auto by_ordinal = exports.find(1, omni::use_ordinal);
+
+  if (by_name != exports.end() && by_name->is_forwarded) {
+    std::println("forwarder: {}.{}",
+      by_name->forwarder_string.module,
+      by_name->forwarder_string.function);
+  }
+}
+```
+
+Pontos importantes:
+
+- `named()` itera apenas exportações nomeadas, enquanto `ordinal()` cobre slots de ordinais;
+- exportações redirecionadas permanecem legíveis via `forwarder_string`;
+- redirecionadores de API-set também podem expor `forwarder_api_set`.
+
+Veja também: [Exportações](exports), [API Sets](api-sets).
+
+## Resolver e chamar WinAPI sem vínculo direto
+
+Use `lazy_import` para chamadas concisas e `lazy_importer<T>` quando quiser um wrapper tipado reutilizável ou metadados da exportação.
+
+```cpp
+#include <Windows.h>
+
+#include "omni/lazy_import.hpp"
+
+#include <array>
+#include <filesystem>
+#include <print>
+
+using get_module_handle_w_fn = HMODULE(WINAPI*)(LPCWSTR);
+using get_system_directory_w_fn = UINT(WINAPI*)(LPWSTR, UINT);
+
+int main() {
+  auto get_module_handle = omni::lazy_importer<get_module_handle_w_fn>{"GetModuleHandleW"};
+  HMODULE kernel32 = get_module_handle(L"kernel32.dll");
+  auto export_entry = get_module_handle.module_export();
+
+  if (kernel32 == nullptr || !export_entry.present()) {
+    return 1;
+  }
+
+  std::array<wchar_t, MAX_PATH> buffer{};
+  auto length = omni::lazy_import<get_system_directory_w_fn>(
+    {"GetSystemDirectoryW", "kernel32.dll"},
+    buffer.data(),
+    static_cast<UINT>(buffer.size())
+  );
+
+  auto process_id = omni::lazy_import<::GetCurrentProcessId>();
+  omni::lazy_import<void>("SetLastError", 0xCAFEU);
+
+  std::println("tamanho do diretório do sistema: {}", length);
+  std::println("pid: {}", process_id);
+}
+```
+
+Pontos importantes:
+
+- use sobrecargas com pares de hash quando múltiplos módulos puderem exportar o mesmo nome;
+- `try_invoke()` mantém os diagnósticos explícitos;
+- exportações resolvidas são mantidas em cache, a menos que `OMNI_DISABLE_CACHING` esteja definido.
+
+Veja também: [Lazy Import](lazy-import), [Utilitários](utilities).
+
+## Chamar NT syscalls com wrappers tipados
+
+Use `syscall` para chamadas curtas e `syscaller<T>` quando quiser reutilização tipada mais diagnósticos.
+
+```cpp
+#include <Windows.h>
+
+#include "omni/syscall.hpp"
+
+#include <cstdint>
+#include <print>
+
+struct process_basic_information {
+  void* reserved1{};
+  void* peb_base_address{};
+  void* reserved2[2]{};
+  std::uintptr_t unique_process_id{};
+  void* reserved3{};
+};
+
+using nt_query_info_process_fn = omni::status (*)(HANDLE, ULONG, void*, ULONG, ULONG*);
+
+int main() {
+  omni::syscaller<nt_query_info_process_fn> query_process{"NtQueryInformationProcess"};
+
+  process_basic_information info{};
+  ULONG return_length{};
+
+  auto result = query_process.try_invoke(
+    ::GetCurrentProcess(),
+    0U,
+    &info,
+    sizeof(info),
+    &return_length
+  );
+
+  if (!result) {
+    std::println("falha: {}", result.error().message());
+    return 1;
+  }
+
+  auto yield_status = omni::syscall<omni::status>("NtYieldExecution");
+  std::println("pid: {}", info.unique_process_id);
+  std::println("yield sucesso: {}", yield_status.is_success());
+}
+```
+
+Pontos importantes:
+
+- suporte a syscalls é exclusivo para x64;
+- `syscall_id_not_found` significa que a exportação não foi reconhecida como um stub de syscall;
+- o analisador de ID de syscall padrão não trata stubs com hooks ou modificados por EDR.
+
+Veja também: [Syscalls](syscalls), [Status](status).
+
+## Ler dados compartilhados de usuário do Windows
+
+Use `omni::shared_user_data()` para ler o mapeamento `KUSER_SHARED_DATA` no nível de processo.
+
+```cpp
+#include "omni/shared_user_data.hpp"
+
+#include <print>
+
+int main() {
+  const auto* shared = omni::shared_user_data();
+
+  std::println("system root  : {}", shared->system_root().string());
+  std::println("versão       : {}.{} build {}",
+    shared->nt_major_version,
+    shared->nt_minor_version,
+    shared->nt_build_number);
+  std::println("processadores: {}", shared->active_processor_count);
+  std::println("frequência QPC: {}", shared->qpc_frequency);
+}
+```
+
+Pontos importantes:
+
+- o mapeamento é fixado em `0x7ffe0000`;
+- leituras são extremamente rápidas e não exigem uma chamada WinAPI;
+- a estrutura pública expõe muitos campos de nível mais baixo para usuários avançados.
+
+Veja também: [Shared User Data](shared-user-data).
+
+## Decodificar e classificar valores NTSTATUS
+
+Use `omni::status` quando precisar de verificações estruturadas para um resultado `NTSTATUS`.
+
+```cpp
+#include "omni/status.hpp"
+
+#include <cstdint>
+#include <print>
+
+int main() {
+  omni::status status = omni::ntstatus::no_more_entries;
+
+  std::println("bruto: 0x{:08X}", static_cast<std::uint32_t>(status.value));
+  std::println("sucesso: {}", status.is_success());
+  std::println("facility: 0x{:03X}", static_cast<std::uint16_t>(status.facility()));
+  std::println("código: 0x{:04X}", static_cast<std::uint16_t>(status.code()));
+}
+```
+
+Pontos importantes:
+
+- `is_success()` segue a semântica NTSTATUS: valores não-negativos representam sucesso;
+- `severity()`, `facility()` e `code()` decodificam o valor bruto;
+- suporte a formatadores está disponível para valores de status.
+
+Veja também: [Status](status).
+
+## Trabalhar com hashes em tempo de compilação e hashers personalizados
+
+Use tipos de hash quando quiser buscas compactas por hashes pré-calculados ou calculados em tempo de compilação.
+
+```cpp
+#include "omni/hash.hpp"
+#include "omni/modules.hpp"
+
+#include <cstdint>
+
+int main() {
+  constexpr omni::fnv1a32 name32{"NtQueryInformationProcess"};
+  constexpr omni::fnv1a64 name64{"NtQueryInformationProcess"};
+  constexpr omni::hash_pair<> lookup{"GetModuleHandleW", "kernel32.dll"};
+
+  auto kernel32 = omni::get_module(omni::default_hash{L"kernel32.dll"});
+  auto export_entry = omni::get_export(lookup.first, lookup.second);
+}
+```
+
+Pontos importantes:
+
+- os hashes são insensíveis a maiúsculas e minúsculas (ASCII case-insensitive);
+- `omni::default_hash` é `omni::fnv1a64`;
+- hashers personalizados podem ser usados em APIs de módulo, exportação, lazy import e syscall.
+
+Veja também: [Utilitários](utilities).
+
+## Inspecionar a resolução de host do API-set
+
+Use `omni::api_sets` quando precisar inspecionar o esquema do API-set do Windows em execução e resolver os hosts de contrato.
+
+```cpp
+#include "omni/api_sets.hpp"
+
+#include <algorithm>
+#include <print>
+#include <ranges>
+
+int main() {
+  omni::api_sets api_sets{};
+
+  auto api_set = api_sets.find_if([](const omni::api_set& item) {
+    return item.default_host().has_value();
+  });
+
+  if (api_set == api_sets.end()) {
+    return 1;
+  }
+
+  auto default_host = api_set->resolve_host();
+  std::println("contrato: {}", api_set->contract_name());
+  std::println("qtd hosts: {}", api_set->hosts().size());
+
+  for (const auto& host : api_set->hosts() | std::views::take(5)) {
+    std::println("{} -> {}", host.alias.empty() ? L"<default>" : host.alias, host.value);
+  }
+}
+```
+
+Pontos importantes:
+
+- `api_sets` é um range sobre o esquema do processo;
+- `default_host()` retorna uma entrada de host caso o contrato esteja implementado;
+- `resolve_host(alias)` aplica regras de fallback do esquema.
+
+Veja também: [API Sets](api-sets), [Exportações](exports).

--- a/content/docs/pt-br/utilities.mdx
+++ b/content/docs/pt-br/utilities.mdx
@@ -46,7 +46,7 @@ constexpr omni::hash_pair<> lookup{"GetSystemDirectoryW", "kernel32.dll"};
 
 ### Literais
 
-O namespace `omni::literals` fornece operadores de literal de string para strings curtas e wide:
+O namespace `omni::literals` fornece operadores de literal de string para strings narrow e wide:
 
 - `"..."_fnv1a32`
 - `"..."_fnv1a64`

--- a/content/docs/pt-br/utilities.mdx
+++ b/content/docs/pt-br/utilities.mdx
@@ -1,0 +1,190 @@
+---
+title: Utilitários
+description: Tipos fundamentais, hashing, conceitos e modelo de erro da omni
+---
+
+## `omni::address`
+
+`omni::address` é um wrapper leve sobre um endereço de memória.
+
+| API | Propósito |
+| --- | --- |
+| construtores | a partir de `nullptr`, `std::uintptr_t`, ponteiro ou range contíguo |
+| `ptr<T>(offset = 0)` | retorna um ponteiro tipado no deslocamento (offset) informado |
+| `value()` | retorna o valor bruto `std::uintptr_t` |
+| `offset<T>(delta = 0)` | gera um endereço ou ponteiro com deslocamento |
+| `as<T>()` | converte o endereço para outro tipo |
+| `span<T>(count)` | visualiza a memória como `std::span` |
+| `is_in_range(start, end)` | verifica se o endereço está dentro de um intervalo |
+| `invoke<T>(args...)` | chama o endereço como uma função |
+
+Suporta conversão explícita para booleano, comparações, operadores aritméticos e bitwise, saída para stream e `std::formatter<omni::address>`.
+
+```cpp
+omni::address base{::GetModuleHandleW(nullptr)};
+auto* image = base.ptr<void>();
+auto entry = base.offset(0x1000);
+```
+
+## API de Hash
+
+### Tipos e funções
+
+- `omni::fnv1a32`
+- `omni::fnv1a64`
+- `omni::default_hash`, um alias para `omni::fnv1a64`
+- `omni::hash_pair<Hasher = default_hash>`
+- `omni::hash<Hasher>(value)`
+
+Os hashes são insensíveis a maiúsculas e minúsculas (ASCII case-insensitive), tornando-os adequados para nomes de módulos e exportações do Windows.
+
+```cpp
+constexpr omni::fnv1a64 kernel32{"kernel32.dll"};
+auto export_hash = omni::hash<omni::fnv1a32>("GetCurrentProcessId");
+constexpr omni::hash_pair<> lookup{"GetSystemDirectoryW", "kernel32.dll"};
+```
+
+### Literais
+
+O namespace `omni::literals` fornece operadores de literal de string para strings curtas e wide:
+
+- `"..."_fnv1a32`
+- `"..."_fnv1a64`
+- `"..."_hash`
+
+### Formatação
+
+Suporte a `std::formatter` está disponível para `omni::fnv1a32` e `omni::fnv1a64`.
+
+## Políticas de hash personalizadas
+
+A maioria das APIs cientes de hash é parametrizada em `Hasher`. A mesma política pode ser usada em módulos, exportações, lazy imports e syscalls.
+
+Um hasher deve satisfazer `omni::concepts::hash`: ele precisa de um `value_type`, `value()`, comparações, construção a partir de strings/valores e hashing para entradas suportadas de string ou span.
+
+```cpp
+using my_hash = omni::fnv1a32;
+
+auto module = omni::get_module(my_hash{L"kernel32.dll"});
+auto export_entry = omni::get_export(my_hash{"GetCurrentProcessId"}, my_hash{"kernel32.dll"});
+auto result = omni::lazy_import<void, my_hash>(my_hash{"SetLastError"}, 0U);
+```
+
+### Implementando seu próprio hasher
+
+Um hasher personalizado é um tipo de valor pequeno, não apenas uma função livre. Ele armazena um valor calculado e também pode ser chamado como um functor de hashing em tempo de execução.
+
+Contrato mínimo:
+
+- definir `using value_type = ...`;
+- fornecer um construtor padrão;
+- construir a partir de `value_type`;
+- construir a partir de literais de string em tempo de compilação (narrow e wide);
+- construir a partir de visões de tempo de execução com suporte a hash, como `std::string_view`;
+- implementar `operator()(omni::concepts::hashable)`;
+- expor `value()`;
+- suportar comparação com outro hasher e com `value_type`.
+
+```cpp
+template <std::unsigned_integral T>
+class djb2_hash {
+  constexpr static auto initial_value = T{5381};
+
+ public:
+  using value_type = T;
+
+  constexpr djb2_hash() = default;
+  constexpr explicit(false) djb2_hash(value_type value): value_(value) {}
+
+  template <typename CharT, std::size_t N>
+  consteval explicit(false) djb2_hash(const CharT (&string)[N]) {
+    for (std::size_t i{}; i < N - 1; i++) {
+      value_ = append(value_, string[i]);
+    }
+  }
+
+  consteval explicit(false) djb2_hash(omni::concepts::hashable auto string) {
+    for (std::size_t i{}; i < string.size(); i++) {
+      value_ = append(value_, string[i]);
+    }
+  }
+
+  [[nodiscard]] value_type operator()(omni::concepts::hashable auto object) {
+    auto value = initial_value;
+    for (std::size_t i{}; i < object.size(); i++) {
+      value = append(value, object[i]);
+    }
+    return value;
+  }
+
+  [[nodiscard]] value_type value() const {
+    return value_;
+  }
+
+  [[nodiscard]] constexpr bool operator==(value_type other) const {
+    return value_ == other;
+  }
+
+  [[nodiscard]] constexpr bool operator==(const djb2_hash& other) const {
+    return value_ == other.value_;
+  }
+
+ private:
+  template <typename CharT>
+  [[nodiscard]] constexpr static value_type append(value_type accumulator, CharT character) {
+    return (accumulator * 33) + static_cast<value_type>(to_lower(character));
+  }
+
+  template <typename CharT>
+  [[nodiscard]] constexpr static CharT to_lower(CharT character) {
+    return ((character >= 'A' && character <= 'Z') ? (character + 32) : character);
+  }
+
+  value_type value_{initial_value};
+};
+
+using djb2_64 = djb2_hash<std::uint64_t>;
+static_assert(omni::concepts::hash<djb2_64>);
+```
+
+### Passando um hasher personalizado para as APIs omni
+
+Assim que o tipo satisfizer `omni::concepts::hash`, passe-o como tipo de valor de hash ou como parâmetro de template explícito `Hasher`.
+
+```cpp
+using my_hash = djb2_64;
+
+auto kernel32 = omni::get_module(my_hash{L"kernel32.dll"});
+auto export_entry = omni::get_export(my_hash{"GetCurrentProcessId"}, my_hash{"kernel32.dll"});
+
+using get_current_process_id_fn = DWORD(WINAPI*)();
+auto process_id = omni::lazy_import<get_current_process_id_fn, my_hash>(my_hash{"GetCurrentProcessId"});
+
+auto status = omni::syscall<omni::status, my_hash>(my_hash{"NtYieldExecution"});
+constexpr omni::hash_pair<my_hash> pair{"GetModuleHandleW", "kernel32.dll"};
+```
+
+Use o mesmo hasher em toda a cadeia de busca. Por exemplo, não crie um `hash_pair<my_hash>` e depois o compare com valores de `omni::default_hash`.
+
+## Conceitos
+
+Conceitos públicos ficam em `omni/concepts.hpp`:
+
+- `omni::concepts::hash`
+- `omni::concepts::hashable`
+- `omni::concepts::function_pointer`
+
+## API de Erro
+
+Valores de `enum class omni::error`:
+
+- `module_not_loaded`
+- `export_not_found`
+- `syscall_id_not_found`
+- `forwarder_string_invalid`
+
+Os erros se integram ao `std::error_code` através de `omni::error_category()`, `omni::make_error_code()` e a especialização padrão de `std::is_error_code_enum`.
+
+```cpp
+std::error_code ec = omni::error::export_not_found;
+```

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,5 +7,6 @@ export const { staticGET: GET } = createFromSource(source, {
   localeMap: {
     en: 'english',
     ru: 'russian',
+    'pt-br': 'portuguese',
   },
 });

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -16,6 +16,7 @@ import { useI18n } from 'fumadocs-ui/contexts/i18n';
 
 function getLanguage(locale?: string) {
   if (locale === 'ru') return 'russian';
+  if (locale === 'pt-br') return 'portuguese';
   return 'english';
 }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -2,7 +2,7 @@ import { defineI18n } from 'fumadocs-core/i18n';
 
 export const i18n = defineI18n({
   defaultLanguage: 'en',
-  languages: ['en', 'ru'],
+  languages: ['en', 'ru', 'pt-br'],
   parser: 'dir',
   hideLocale: 'never',
   fallbackLanguage: null,
@@ -11,4 +11,5 @@ export const i18n = defineI18n({
 export const localeNames: Record<string, string> = {
   en: 'English',
   ru: 'Русский',
+  'pt-br': 'Português (Brasil)',
 };

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -30,6 +30,19 @@ export const i18nUI = defineI18nUI(i18n, {
     chooseTheme: 'Выбрать тему',
     editOnGithub: 'Редактировать на GitHub',
   },
+  'pt-br': {
+    displayName: localeNames['pt-br'],
+    search: 'Buscar',
+    searchNoResult: 'Nenhum resultado encontrado',
+    toc: 'Nesta página',
+    tocNoHeadings: 'Sem cabeçalhos',
+    lastUpdate: 'Última atualização',
+    chooseLanguage: 'Escolher idioma',
+    nextPage: 'Próxima página',
+    previousPage: 'Página anterior',
+    chooseTheme: 'Escolher tema',
+    editOnGithub: 'Editar no GitHub',
+  },
 });
 
 export function baseOptions(locale: string): BaseLayoutProps {


### PR DESCRIPTION
This PR adds full Portuguese (Brazil) translation for the omni documentation.

- Added `content/docs/pt-br/` with all 13 documentation pages translated to PT-BR.
 - Updated `src/lib/i18n.ts`, `src/lib/layout.shared.tsx`, `src/components/search.tsx`, and `src/app/api/search/route.ts` to support `pt-br` locale and search indexing.