### PR TITLE
refactor(unicode_string): use 'auto' for type deduction of utf8_str

### DIFF
--- a/include/omni/win/unicode_string.hpp
+++ b/include/omni/win/unicode_string.hpp
@@ -36,7 +36,7 @@ namespace omni::win {
         return result;
       }
 
-      std::u8string utf8_str = to_path().u8string();
+      auto utf8_str = to_path().u8string();
       return {reinterpret_cast<const char*>(utf8_str.data()), utf8_str.size()};
     }
 

--- a/single_header/omni.hpp
+++ b/single_header/omni.hpp
@@ -2006,7 +2006,7 @@ namespace omni::win {
         return result;
       }
 
-      std::u8string utf8_str = to_path().u8string();
+      auto utf8_str = to_path().u8string();
       return {reinterpret_cast<const char*>(utf8_str.data()), utf8_str.size()};
     }
 


### PR DESCRIPTION
`omni` gives compilation error when uses `/Zc:char8_t-` compiler options, because it uses strict result type in `unicode_string.hpp:39`. I replaced `std::u8string` ->`auto` to fix that, because:
<img width="1026" height="165" alt="image" src="https://github.com/user-attachments/assets/4b6917b8-e76b-44cc-8009-90e44440ec6d" />
